### PR TITLE
Use the package name `tripper` (not `tripperpy`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ _The best ride when handling any triplestore._
 
 ## Installation
 
-The package can be installed from [PyPI](https://pypi.org/project/tripperpy) using `pip`:
+The package can be installed from [PyPI](https://pypi.org/project/tripper) using `pip`:
 
 ```shell
-pip install tripperpy
+pip install tripper
 ```
 
 ## License and copyright

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,10 +6,10 @@ _The best ride when handling any triplestore._
 
 ## Installation
 
-The package can be installed from [PyPI](https://pypi.org/project/tripperpy) using `pip`:
+The package can be installed from [PyPI](https://pypi.org/project/tripper) using `pip`:
 
 ```shell
-pip install tripperpy
+pip install tripper
 ```
 
 ## License and copyright

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["flit_core >=3.4,<4"]
 build-backend = "flit_core.buildapi"
 
 [project]
-name = "tripperpy"
+name = "tripper"
 authors = [
     {name = "Jesper Friis", email = "jesper.friis@sintef.no"},
     {name = "Casper Welzel Andersen", email = "casper.w.andersen@sintef.no"},
@@ -69,9 +69,6 @@ Source = "https://github.com/EMMC-ASBL/tripper"
 "Issue Tracker" = "https://github.com/EMMC-ASBL/tripper/issues"
 Changelog = "https://github.com/EMMC-ASBL/tripper/blob/main/CHANGELOG.md"
 Package = "https://pypi.org/project/tripper"
-
-[tool.flit.module]
-name = "tripper"
 
 [tool.mypy]
 python_version = "3.7"


### PR DESCRIPTION
Closes #13 

The `tripper` package name has been released and claimed by us.
This PR updates the package name accordingly, so that the package can now be installed via `pip install tripper`.

Note: The previous package name (`tripperpy`) will become a proxy package for `tripper`.