### PR TITLE
Add a useful description to README file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ In Tripper:
   Example: `tripper.Literal(3.14, datatype=XSD.float)`
 
 To make it easy to work with IRIs, provide Tripper a set of pre-defined namespaces, like `XSD.float`.
-New namespaces can easily be defined with the [`tripper.Namespace`][Namespace] class.
+New namespaces can be defined with the [`tripper.Namespace`][Namespace] class.
 
 A triplestore wrapper is created with the [`tripper.Triplestore`][Triplestore] class.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ _Triplestore wrapper for Python providing a simple and consistent interface to a
 
 [![PyPI](https://img.shields.io/pypi/v/tripper?logo=pypi)](https://pypi.org/project/tripper)
 [![Documentation](https://img.shields.io/badge/documentation-informational?logo=github)](https://emmc-asbl.github.io/tripper/latest/)
-![CI tests](https://github.com/EMMC-ASBL/tripper/workflows/CI%20-%20Tests/badge.svg)
+[![CI tests](https://github.com/EMMC-ASBL/tripper/workflows/CI%20-%20Tests/badge.svg)](https://github.com/EMMC-ASBL/tripper/actions/workflows/ci_tests.yml?query=branch%3Amain)
 
 
 Basic concepts

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 Tripper
 =======
-_Triplestore wrapper for Python providing a simple and consistent interface to a range of triplestore backends._
+_Triplestore wrapper for Python providing a simple and consistent interface to a range of triplestore backends - the best ride when handling any triplestore._
+
 
 [![PyPI](https://img.shields.io/pypi/v/tripper?logo=pypi)](https://pypi.org/project/tripper)
 [![Documentation](https://img.shields.io/badge/documentation-informational?logo=github)](https://emmc-asbl.github.io/tripper/latest/)
@@ -48,7 +49,10 @@ pip install tripper
 
 License and copyright
 ---------------------
-All files in this repository are licensed under the [MIT license](LICENSE) with copyright &copy; 2022 SINTEF.
+All files in this repository are licensed under the [MIT license](LICENSE).
+If not stated otherwise in the top of the file, it has copyright &copy; 2022
+SINTEF.
+
 
 
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ pip install tripper
 
 License and copyright
 ---------------------
-All files in this repository are licensed under the [MIT license](LICENSE) with copyright &copy; 2022 European Material Modelling Council.
+All files in this repository are licensed under the [MIT license](LICENSE) with copyright &copy; 2022 SINTEF.
 
 
 

--- a/README.md
+++ b/README.md
@@ -39,8 +39,7 @@ Documentation
 
 Installation
 ------------
-**Tripper** has by itself no dependencies outside the standard
-library, but the triplestore backends may have.
+Tripper has by itself no dependencies outside the standard library, but the triplestore backends may have specific dependencies.
 
 
 The package can be installed from [PyPI] using `pip`:

--- a/README.md
+++ b/README.md
@@ -1,23 +1,31 @@
 Tripper
 =======
-**Tripper** is triplestore wrapper for Python providing a simple and
-consistent interface to a range of triplestore backends.
+_Triplestore wrapper for Python providing a simple and consistent interface to a range of triplestore backends._
 
-The interface of **Tripper** strives for simplicity and is modelled
-after [rdflib] (with a few simplifications).
+![CI tests](https://github.com/EMMC-ASBL/tripper/workflows/CI%20-%20Tests/badge.svg)
+[![PyPI version](https://badge.fury.io/py/tripper.svg)](https://badge.fury.io/py/tripper)
+
 
 
 Basic concepts
 --------------
+**Tripper** strives for simplicity and is modelled after [rdflib] (with a few simplifications).
+
 In Tripper are:
-- all IRIs are represented by Python strings
-- blank nodes are strings starting with "_:"
-- literals are constructed with `tripper.Literal`
+* All IRIs are represented by Python strings.
+  Example: `"http://emmo.info/emmo#Atom"`
 
-Tripper offers the `tripper.Namespace` class for simplifying working
-with namespaces and writing IRIs.
+* Blank nodes are strings starting with "_:".
+  Example: `"_:bnode1"`
 
-A triplestore wrapper is created by instantiating `tripper.Triplestore`.
+* Literals are constructed with `tripper.Literal`.
+  Example: `tripper.Literal(3.14, datatype=XSD.float)`
+
+To make it easy to work with IRIs, provide Tripper a set of pre-defined namespaces, like `XSD.float`.
+New namespaces can easily be defined with the `tripper.Namespace` class.
+
+A triplestore wrapper is created with the `tripper.Triplestore` class.
+
 
 
 Getting started

--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ Basic concepts
 Tripper provides a simple and consistent interface to a range of triplestore backends.
 It strives for simplicity and is modelled after [rdflib] (with a few simplifications).
 
-In Tripper are:
+In Tripper:
+
 * All IRIs are represented by Python strings.
   Example: `"http://emmo.info/emmo#Atom"`
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ _Triplestore wrapper for Python providing a simple and consistent interface to a
 
 Basic concepts
 --------------
-**Tripper** strives for simplicity and is modelled after [rdflib] (with a few simplifications).
+Tripper provides a simple and consistent interface to a range of triplestore backends.
+It strives for simplicity and is modelled after [rdflib] (with a few simplifications).
 
 In Tripper are:
 * All IRIs are represented by Python strings.

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@ Tripper
 =======
 _Triplestore wrapper for Python providing a simple and consistent interface to a range of triplestore backends._
 
+[![PyPI](https://img.shields.io/pypi/v/tripper?logo=pypi)](https://pypi.org/project/tripper)
+[![Documentation](https://img.shields.io/badge/documentation-informational?logo=github)](https://emmc-asbl.github.io/tripper/latest/)
 ![CI tests](https://github.com/EMMC-ASBL/tripper/workflows/CI%20-%20Tests/badge.svg)
-[![PyPI version](https://badge.fury.io/py/tripper.svg)](https://badge.fury.io/py/tripper)
-
 
 
 Basic concepts
@@ -18,19 +18,20 @@ In Tripper are:
 * Blank nodes are strings starting with "_:".
   Example: `"_:bnode1"`
 
-* Literals are constructed with `tripper.Literal`.
+* Literals are constructed with [`tripper.Literal`][Literal].
   Example: `tripper.Literal(3.14, datatype=XSD.float)`
 
 To make it easy to work with IRIs, provide Tripper a set of pre-defined namespaces, like `XSD.float`.
-New namespaces can easily be defined with the `tripper.Namespace` class.
+New namespaces can easily be defined with the [`tripper.Namespace`][Namespace] class.
 
-A triplestore wrapper is created with the `tripper.Triplestore` class.
+A triplestore wrapper is created with the [`tripper.Triplestore`][Triplestore] class.
 
 
 
-Getting started
----------------
-Take a look at the [tutorial](docs/tutorial.md) to get started.
+Documentation
+-------------
+* Getting started: Take a look at the [tutorial](docs/tutorial.md).
+* Reference manual: [API Reference]
 
 
 Installation
@@ -39,7 +40,7 @@ Installation
 library, but the triplestore backends may have.
 
 
-The package can be installed from [PyPI](https://pypi.org/project/tripper) using `pip`:
+The package can be installed from [PyPI] using `pip`:
 
 ```shell
 pip install tripper
@@ -52,3 +53,8 @@ All files in this repository are licensed under the [MIT license](LICENSE) with 
 
 
 [rdflib]: https://rdflib.readthedocs.io/en/stable/
+[PyPI]: https://pypi.org/project/tripper
+[API Reference]: https://emmc-asbl.github.io/tripper/latest/api_reference/triplestore/
+[Literal]: https://emmc-asbl.github.io/tripper/latest/api_reference/triplestore/#tripper.triplestore.Literal
+[Namespace]: https://emmc-asbl.github.io/tripper/latest/api_reference/triplestore/#tripper.triplestore.Namespace
+[Triplestore]: https://emmc-asbl.github.io/tripper/latest/api_reference/triplestore/#tripper.triplestore.Triplestore

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ pip install tripper
 License and copyright
 ---------------------
 All files in this repository are licensed under the [MIT license](LICENSE).
-If not stated otherwise in the top of the file, it has copyright &copy; 2022
+If not stated otherwise in the top of the files, they have copyright &copy; 2022
 SINTEF.
 
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,35 @@
-# Tripper
+Tripper
+=======
+**Tripper** is triplestore wrapper for Python providing a simple and
+consistent interface to a range of triplestore backends.
 
-**A triplestore wrapper for Python.**
-
-_The best ride when handling any triplestore._
-
-See the [documentation](docs/overview.md) for a quick tutorial.
+The interface of **Tripper** strives for simplicity and is modelled
+after [rdflib] (with a few simplifications).
 
 
-## Installation
+Basic concepts
+--------------
+In Tripper are:
+- all IRIs are represented by Python strings
+- blank nodes are strings starting with "_:"
+- literals are constructed with `tripper.Literal`
+
+Tripper offers the `tripper.Namespace` class for simplifying working
+with namespaces and writing IRIs.
+
+A triplestore wrapper is created by instantiating `tripper.Triplestore`.
+
+
+Getting started
+---------------
+Take a look at the [tutorial](docs/tutorial.md) to get started.
+
+
+Installation
+------------
+**Tripper** has by itself no dependencies outside the standard
+library, but the triplestore backends may have.
+
 
 The package can be installed from [PyPI](https://pypi.org/project/tripper) using `pip`:
 
@@ -15,6 +37,10 @@ The package can be installed from [PyPI](https://pypi.org/project/tripper) using
 pip install tripper
 ```
 
-## License and copyright
-
+License and copyright
+---------------------
 All files in this repository are licensed under the [MIT license](LICENSE) with copyright &copy; 2022 European Material Modelling Council.
+
+
+
+[rdflib]: https://rdflib.readthedocs.io/en/stable/

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,10 +1,11 @@
 Tripper
 =======
-_Triplestore wrapper for Python providing a simple and consistent interface to a range of triplestore backends._
+_Triplestore wrapper for Python providing a simple and consistent interface to a range of triplestore backends - the best ride when handling any triplestore._
+
 
 [![PyPI](https://img.shields.io/pypi/v/tripper?logo=pypi)](https://pypi.org/project/tripper)
 [![Documentation](https://img.shields.io/badge/documentation-informational?logo=github)](https://emmc-asbl.github.io/tripper/latest/)
-![CI tests](https://github.com/EMMC-ASBL/tripper/workflows/CI%20-%20Tests/badge.svg)
+[![CI tests](https://github.com/EMMC-ASBL/tripper/workflows/CI%20-%20Tests/badge.svg)](https://github.com/EMMC-ASBL/tripper/actions/workflows/ci_tests.yml?query=branch%3Amain)
 
 
 Basic concepts
@@ -48,7 +49,10 @@ pip install tripper
 
 License and copyright
 ---------------------
-All files in this repository are licensed under the [MIT license](LICENSE.md) with copyright &copy; 2022 SINTEF.
+All files in this repository are licensed under the [MIT license](LICENSE.md).
+If not stated otherwise in the top of the file, it has copyright &copy; 2022
+SINTEF.
+
 
 
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,13 +1,35 @@
-# Tripper
+Tripper
+=======
+**Tripper** is triplestore wrapper for Python providing a simple and
+consistent interface to a range of triplestore backends.
 
-**A triplestore wrapper for Python.**
-
-_The best ride when handling any triplestore._
-
-See the [documentation](overview.md) for a quick tutorial.
+The interface of **Tripper** strives for simplicity and is modelled
+after [rdflib] (with a few simplifications).
 
 
-## Installation
+Basic concepts
+--------------
+In Tripper are:
+- all IRIs are represented by Python strings
+- blank nodes are strings starting with "_:"
+- literals are constructed with `tripper.Literal`
+
+Tripper offers the `tripper.Namespace` class for simplifying working
+with namespaces and writing IRIs.
+
+A triplestore wrapper is created by instantiating `tripper.Triplestore`.
+
+
+Getting started
+---------------
+Take a look at the [tutorial](tutorial.md) to get started.
+
+
+Installation
+------------
+**Tripper** has by itself no dependencies outside the standard
+library, but the triplestore backends may have.
+
 
 The package can be installed from [PyPI](https://pypi.org/project/tripper) using `pip`:
 
@@ -15,6 +37,10 @@ The package can be installed from [PyPI](https://pypi.org/project/tripper) using
 pip install tripper
 ```
 
-## License and copyright
-
+License and copyright
+---------------------
 All files in this repository are licensed under the [MIT license](LICENSE.md) with copyright &copy; 2022 European Material Modelling Council.
+
+
+
+[rdflib]: https://rdflib.readthedocs.io/en/stable/

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,23 +1,31 @@
 Tripper
 =======
-**Tripper** is triplestore wrapper for Python providing a simple and
-consistent interface to a range of triplestore backends.
+_Triplestore wrapper for Python providing a simple and consistent interface to a range of triplestore backends._
 
-The interface of **Tripper** strives for simplicity and is modelled
-after [rdflib] (with a few simplifications).
+![CI tests](https://github.com/EMMC-ASBL/tripper/workflows/CI%20-%20Tests/badge.svg)
+[![PyPI version](https://badge.fury.io/py/tripper.svg)](https://badge.fury.io/py/tripper)
+
 
 
 Basic concepts
 --------------
+**Tripper** strives for simplicity and is modelled after [rdflib] (with a few simplifications).
+
 In Tripper are:
-- all IRIs are represented by Python strings
-- blank nodes are strings starting with "_:"
-- literals are constructed with `tripper.Literal`
+* All IRIs are represented by Python strings.
+  Example: `"http://emmo.info/emmo#Atom"`
 
-Tripper offers the `tripper.Namespace` class for simplifying working
-with namespaces and writing IRIs.
+* Blank nodes are strings starting with "_:".
+  Example: `"_:bnode1"`
 
-A triplestore wrapper is created by instantiating `tripper.Triplestore`.
+* Literals are constructed with `tripper.Literal`.
+  Example: `tripper.Literal(3.14, datatype=XSD.float)`
+
+To make it easy to work with IRIs, provide Tripper a set of pre-defined namespaces, like `XSD.float`.
+New namespaces can easily be defined with the `tripper.Namespace` class.
+
+A triplestore wrapper is created with the `tripper.Triplestore` class.
+
 
 
 Getting started

--- a/docs/index.md
+++ b/docs/index.md
@@ -48,7 +48,7 @@ pip install tripper
 
 License and copyright
 ---------------------
-All files in this repository are licensed under the [MIT license](LICENSE.md) with copyright &copy; 2022 European Material Modelling Council.
+All files in this repository are licensed under the [MIT license](LICENSE.md) with copyright &copy; 2022 SINTEF.
 
 
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,9 +10,11 @@ _Triplestore wrapper for Python providing a simple and consistent interface to a
 
 Basic concepts
 --------------
-**Tripper** strives for simplicity and is modelled after [rdflib] (with a few simplifications).
+Tripper provides a simple and consistent interface to a range of triplestore backends.
+It strives for simplicity and is modelled after [rdflib] (with a few simplifications).
 
-In Tripper are:
+In Tripper:
+
 * All IRIs are represented by Python strings.
   Example: `"http://emmo.info/emmo#Atom"`
 
@@ -23,7 +25,7 @@ In Tripper are:
   Example: `tripper.Literal(3.14, datatype=XSD.float)`
 
 To make it easy to work with IRIs, provide Tripper a set of pre-defined namespaces, like `XSD.float`.
-New namespaces can easily be defined with the [`tripper.Namespace`][Namespace] class.
+New namespaces can be defined with the [`tripper.Namespace`][Namespace] class.
 
 A triplestore wrapper is created with the [`tripper.Triplestore`][Triplestore] class.
 
@@ -37,8 +39,7 @@ Documentation
 
 Installation
 ------------
-**Tripper** has by itself no dependencies outside the standard
-library, but the triplestore backends may have.
+Tripper has by itself no dependencies outside the standard library, but the triplestore backends may have specific dependencies.
 
 
 The package can be installed from [PyPI] using `pip`:

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,9 +2,9 @@ Tripper
 =======
 _Triplestore wrapper for Python providing a simple and consistent interface to a range of triplestore backends._
 
+[![PyPI](https://img.shields.io/pypi/v/tripper?logo=pypi)](https://pypi.org/project/tripper)
+[![Documentation](https://img.shields.io/badge/documentation-informational?logo=github)](https://emmc-asbl.github.io/tripper/latest/)
 ![CI tests](https://github.com/EMMC-ASBL/tripper/workflows/CI%20-%20Tests/badge.svg)
-[![PyPI version](https://badge.fury.io/py/tripper.svg)](https://badge.fury.io/py/tripper)
-
 
 
 Basic concepts
@@ -18,19 +18,20 @@ In Tripper are:
 * Blank nodes are strings starting with "_:".
   Example: `"_:bnode1"`
 
-* Literals are constructed with `tripper.Literal`.
+* Literals are constructed with [`tripper.Literal`][Literal].
   Example: `tripper.Literal(3.14, datatype=XSD.float)`
 
 To make it easy to work with IRIs, provide Tripper a set of pre-defined namespaces, like `XSD.float`.
-New namespaces can easily be defined with the `tripper.Namespace` class.
+New namespaces can easily be defined with the [`tripper.Namespace`][Namespace] class.
 
-A triplestore wrapper is created with the `tripper.Triplestore` class.
+A triplestore wrapper is created with the [`tripper.Triplestore`][Triplestore] class.
 
 
 
-Getting started
----------------
-Take a look at the [tutorial](tutorial.md) to get started.
+Documentation
+-------------
+* Getting started: Take a look at the [tutorial](tutorial.md).
+* Reference manual: [API Reference]
 
 
 Installation
@@ -39,7 +40,7 @@ Installation
 library, but the triplestore backends may have.
 
 
-The package can be installed from [PyPI](https://pypi.org/project/tripper) using `pip`:
+The package can be installed from [PyPI] using `pip`:
 
 ```shell
 pip install tripper
@@ -52,3 +53,8 @@ All files in this repository are licensed under the [MIT license](LICENSE.md) wi
 
 
 [rdflib]: https://rdflib.readthedocs.io/en/stable/
+[PyPI]: https://pypi.org/project/tripper
+[API Reference]: https://emmc-asbl.github.io/tripper/latest/api_reference/triplestore/
+[Literal]: https://emmc-asbl.github.io/tripper/latest/api_reference/triplestore/#tripper.triplestore.Literal
+[Namespace]: https://emmc-asbl.github.io/tripper/latest/api_reference/triplestore/#tripper.triplestore.Namespace
+[Triplestore]: https://emmc-asbl.github.io/tripper/latest/api_reference/triplestore/#tripper.triplestore.Triplestore

--- a/docs/index.md
+++ b/docs/index.md
@@ -50,7 +50,7 @@ pip install tripper
 License and copyright
 ---------------------
 All files in this repository are licensed under the [MIT license](LICENSE.md).
-If not stated otherwise in the top of the file, it has copyright &copy; 2022
+If not stated otherwise in the top of the files, they have copyright &copy; 2022
 SINTEF.
 
 

--- a/docs/planned-backends.md
+++ b/docs/planned-backends.md
@@ -1,0 +1,11 @@
+Additional backends
+===================
+Backends that could be supported in upcoming versions
+  - owlready2/EMMOntoPy
+  - OntoRec/OntoFlowKB
+  - Stardog
+  - DLite triplestore (based on Redland librdf)
+  - Redland librdf
+  - Apache Jena Fuseki
+  - Allegrograph
+  - Wikidata

--- a/docs/planned-backends.md
+++ b/docs/planned-backends.md
@@ -1,7 +1,8 @@
-Additional backends
-===================
-Backends that could be supported in upcoming versions
-  - owlready2/EMMOntoPy
+Planned backends
+================
+In addition to the currently existing backends, the following
+additional backends may be supported in upcoming versions:
+
   - OntoRec/OntoFlowKB
   - Stardog
   - DLite triplestore (based on Redland librdf)

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -1,18 +1,8 @@
-# Overview
-
+Tutorial
+========
 <!-- markdownlint-disable MD007 -->
 
-A Python package encapsulating different triplestores using the strategy design pattern.
-
-This package has by itself no dependencies outside the standard library, but the triplestore backends may have.
-
-The main class is Triplestore, who's `__init__()` method takes the name of the backend to encapsulate as first argument.
-Its interface is strongly inspired by rdflib.Graph, but simplified when possible to make it easy to use.
-Some important differences:
-
-- all IRIs are represented by Python strings
-- blank nodes are strings starting with "_:"
-- literals are constructed with `Literal()`
+Create a triplestore instance using the `rdflib` backend:
 
 ```python
 from triplestore import Triplestore
@@ -36,7 +26,7 @@ ONTO.MyConcept
 # -> 'http://example.com/onto#MyConcept'
 ```
 
-Namespace also support access by label and IRI checking.
+Namespace also supports access by label and IRI checking.
 Both of these features requires loading an ontology.
 The following example shows how to create an EMMO namespace with IRI checking.
 The keyword argument `label_annotations=True` enables access by `skos:prefLabel`, `rdfs:label` or `skos:altLabel`.
@@ -121,18 +111,3 @@ ts.add_function(
     returns=ONTO.AverageArmLength,
 )
 ```
-
-## Further development
-
-- Update the `query()` method to return the SPARQL result in a backend-independent way.
-- Add additional backends. Candidates include:
-
-    - list of tuples
-    - owlready2/EMMOntoPy
-    - OntoRec/OntoFlowKB
-    - Stardog
-    - DLite triplestore (based on Redland librdf)
-    - Redland librdf
-    - Apache Jena Fuseki
-    - Allegrograph
-    - Wikidata

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -79,7 +79,7 @@ plugins:
 
 nav:
   - Home: index.md
-  - Overview: overview.md
+  - Tutorial: tutorial.md
   - License: LICENSE.md
   - Changelog: CHANGELOG.md
   - ... | api_reference/**


### PR DESCRIPTION
Closes #18 

If the mkdocs generated reference documentation is available somewhere, then a link should be added to it from the README file. 