### PR TITLE
Use the proper version of SINTEF/ci-cd

### DIFF
--- a/.github/workflows/cd_release.yml
+++ b/.github/workflows/cd_release.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   publish-package-and-docs:
     name: External
-    uses: SINTEF/ci-cd/.github/workflows/cd_release.yml@v1.3.4
+    uses: SINTEF/ci-cd/.github/workflows/cd_release.yml@v1
     if: github.repository == 'EMMC-ASBL/tripper' && startsWith(github.ref, 'refs/tags/v')
     with:
       # General

--- a/.github/workflows/ci_automerge_dependency_prs.yml
+++ b/.github/workflows/ci_automerge_dependency_prs.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   update-dependencies-branch:
     name: External
-    uses: SINTEF/ci-cd/.github/workflows/ci_automerge_prs.yml@v1.3.4
+    uses: SINTEF/ci-cd/.github/workflows/ci_automerge_prs.yml@v1
     if: github.repository_owner == 'EMMC-ASBL' && ( ( startsWith(github.event.pull_request.head.ref, 'dependabot/') && github.actor == 'dependabot[bot]' ) || ( github.event.pull_request.head.ref == 'ci/update-pyproject' && github.actor == 'TEAM4-0' ) )
     secrets:
       PAT: ${{ secrets.RELEASE_PAT }}

--- a/.github/workflows/ci_cd_updated_main.yml
+++ b/.github/workflows/ci_cd_updated_main.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   update-deps-branch-and-docs:
     name: External
-    uses: SINTEF/ci-cd/.github/workflows/ci_cd_updated_default_branch.yml@v1.3.4
+    uses: SINTEF/ci-cd/.github/workflows/ci_cd_updated_default_branch.yml@v1
     if: github.repository_owner == 'EMMC-ASBL'
     with:
       git_username: "TEAM 4.0[bot]"

--- a/.github/workflows/ci_check_dependencies.yml
+++ b/.github/workflows/ci_check_dependencies.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   check-dependencies:
     name: External
-    uses: SINTEF/ci-cd/.github/workflows/ci_check_pyproject_dependencies.yml@v1.3.4
+    uses: SINTEF/ci-cd/.github/workflows/ci_check_pyproject_dependencies.yml@v1
     if: github.repository_owner == 'EMMC-ASBL'
     with:
       git_username: "TEAM 4.0[bot]"

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   basic-tests:
     name: External
-    uses: SINTEF/ci-cd/.github/workflows/ci_tests.yml@v1.3.4
+    uses: SINTEF/ci-cd/.github/workflows/ci_tests.yml@v1
     with:
       # General settings:
       install_extras: "[dev]"

--- a/.github/workflows/ci_update_dependencies.yml
+++ b/.github/workflows/ci_update_dependencies.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   create-collected-pr:
     name: External
-    uses: SINTEF/ci-cd/.github/workflows/ci_update_dependencies.yml@v1.3.4
+    uses: SINTEF/ci-cd/.github/workflows/ci_update_dependencies.yml@v1
     if: github.repository_owner == 'EMMC-ASBL'
     with:
       git_username: "TEAM 4.0[bot]"

--- a/tripper/literal.py
+++ b/tripper/literal.py
@@ -64,6 +64,8 @@ class Literal(str):
             elif isinstance(value, float):
                 string.datatype = XSD.double
             elif isinstance(value, (bytes, bytearray)):
+                # Re-initialize the value anew, similarly to what is done in the first
+                # line of this method.
                 string = super().__new__(cls, value.hex())
                 string.lang = None
                 string.datatype = XSD.hexBinary

--- a/tripper/literal.py
+++ b/tripper/literal.py
@@ -6,20 +6,22 @@ from typing import TYPE_CHECKING
 from tripper.namespace import OWL, RDF, RDFS, XSD
 
 if TYPE_CHECKING:  # pragma: no cover
-    from typing import Any, Tuple, Union
+    from typing import Any, Optional, Union
 
 
 class Literal(str):
     """A literal RDF value.
 
     Arguments:
-        value: The literal value.  See the `datatypes` class attribute for
-            valid supported data types.  A localised string is provided as
-            a string with `lang` set to a language code.
-        lang: A standard language code, like "en", "no", etc.  Implies that
-            the `value` is a localised string.
-        datatype: Explicit specification of the type of `value`. Should not
-            be combined with `lang`.
+        value (Union[datetime, bytes, bytearray, bool, int, float, str]): The literal
+            value. See the `datatypes` class attribute for valid supported data types.
+            A localised string is provided as a string with `lang` set to a language
+            code.
+        lang (Optional[str]): A standard language code, like "en", "no", etc. Implies
+            that the `value` is a localised string.
+        datatype (Any): Explicit specification of the type of `value`. Should not be
+            combined with `lang`.
+
     """
 
     lang: "Union[str, None]"
@@ -37,7 +39,12 @@ class Literal(str):
         str: XSD.string,
     }
 
-    def __new__(cls, value, lang=None, datatype=None):
+    def __new__(
+        cls,
+        value: "Union[datetime, bytes, bytearray, bool, int, float, str]",
+        lang: "Optional[str]" = None,
+        datatype: "Optional[Any]" = None,
+    ):
         string = super().__new__(cls, value)
         if lang:
             if datatype:
@@ -57,7 +64,8 @@ class Literal(str):
             elif isinstance(value, float):
                 string.datatype = XSD.double
             elif isinstance(value, (bytes, bytearray)):
-                string = value.hex()
+                string = super().__new__(cls, value.hex())
+                string.lang = None
                 string.datatype = XSD.hexBinary
             elif isinstance(value, datetime):
                 string.datatype = XSD.dateTime

--- a/tripper/utils.py
+++ b/tripper/utils.py
@@ -8,8 +8,7 @@ from tripper.literal import Literal
 from tripper.namespace import XSD
 
 if TYPE_CHECKING:  # pragma: no cover
-    from collections.abc import Mapping
-    from typing import Any, Callable, Dict, Generator, Tuple, Union
+    from typing import Any, Callable, Tuple
 
 
 def infer_iri(obj):
@@ -89,9 +88,10 @@ def parse_literal(literal: "Any") -> "Literal":
         return literal
 
     if not isinstance(literal, str):
-        for type_, datatype in Literal.datatypes.items():
-            if isinstance(literal, type_):
-                return Literal(literal, lang=lang, datatype=datatype)
+        if isinstance(literal, tuple(Literal.datatypes)):
+            return Literal(
+                literal, lang=lang, datatype=Literal.datatypes.get(type(literal))
+            )
         TypeError(f"unsupported literal type: {type(literal)}")
 
     match = re.match(r'^\s*("""(.*)"""|"(.*)")\s*$', literal, flags=re.DOTALL)


### PR DESCRIPTION
Closes #33 
Closes #35 

Return to using `v1` for SINTEF/ci-cd callable workflows.
Add missing type annotations to ensure warning-free documentation build.