### PR TITLE
Added collection backend

### DIFF
--- a/docs/api_reference/backends/collection.md
+++ b/docs/api_reference/backends/collection.md
@@ -1,0 +1,3 @@
+# collection
+
+::: tripper.backends.collection

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "EMMOntoPy ~=0.4",
     "rdflib ~=6.2",
     "SPARQLWrapper ~=2.0",
+    "DLite-Python >=0.3.15",
     "typing-extensions ~=4.4 ; python_version<'3.8'",
 ]
 

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -7,7 +7,7 @@ ts = Triplestore(backend="collection")
 assert not list(ts.triples((None, None, None)))
 
 STRUCTURE = ts.bind("structure", "http://onto-ns.com/meta/0.1/Structure#")
-CIF = ts.bind("cif", "http://emmo.info/cif-ontology/0.1#")
+CIF = ts.bind("cif", "http://emmo.info/0.1/cif-ontology#")
 triples = [
     (STRUCTURE.symbols, MAP.mapsTo, EMMO.Symbol),
     (STRUCTURE.positions, MAP.mapsTo, EMMO.PositionVector),

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -1,0 +1,20 @@
+"""Test collection."""
+from tripper import EMMO, MAP, Triplestore
+
+ts = Triplestore(backend="collection")
+assert not list(ts.triples((None, None, None)))
+
+STRUCTURE = ts.bind("structure", "http://onto-ns.com/meta/0.1/Structure#")
+CIF = ts.bind("cif", "http://emmo.info/cif-ontology/0.1#")
+triples = [
+    (STRUCTURE.symbols, MAP.mapsTo, EMMO.Symbol),
+    (STRUCTURE.positions, MAP.mapsTo, EMMO.PositionVector),
+    (STRUCTURE.cell, MAP.mapsTo, CIF.cell),
+    (STRUCTURE.masses, MAP.mapsTo, EMMO.Mass),
+]
+
+ts.add_triples(triples)
+assert set(ts.triples((None, None, None))) == set(triples)
+
+ts.remove((None, None, EMMO.Mass))
+assert set(ts.triples((None, None, None))) == set(triples[:-1])

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -1,4 +1,6 @@
 """Test collection."""
+import dlite
+
 from tripper import EMMO, MAP, Triplestore
 
 ts = Triplestore(backend="collection")
@@ -18,3 +20,11 @@ assert set(ts.triples((None, None, None))) == set(triples)
 
 ts.remove((None, None, EMMO.Mass))
 assert set(ts.triples((None, None, None))) == set(triples[:-1])
+
+
+# Test that we can initialise from an existing collection
+coll = dlite.Collection()
+for triple in triples:
+    coll.add_relation(*triple)
+ts2 = Triplestore(backend="collection", collection=coll)
+assert set(ts2.triples((None, None, None))) == set(triples)

--- a/tests/test_triplestore.py
+++ b/tests/test_triplestore.py
@@ -13,8 +13,8 @@ if TYPE_CHECKING:
     from typing import Any, Callable
 
 
-# @pytest.mark.parametrize("backend", ["ontopy", "rdflib"])
-@pytest.mark.parametrize("backend", ["rdflib"])
+# @pytest.mark.parametrize("backend", ["rdflib", "ontopy", "collection"])
+@pytest.mark.parametrize("backend", ["rdflib", "collection"])
 def test_triplestore(
     backend: str,
     example_function: "Callable[[Any, Any], Any]",
@@ -53,25 +53,33 @@ def test_triplestore(
         base_iri=EX,
     )
 
-    ts_as_turtle = store.serialize(format="turtle")
-    assert ts_as_turtle == expected_function_triplestore
+    try:
+        ts_as_turtle = store.serialize(format="turtle")
+    except NotImplementedError:
+        pass
+    else:
+        assert ts_as_turtle == expected_function_triplestore
 
     # Test SPARQL query
-    rows = store.query("SELECT ?s ?o WHERE { ?s rdfs:subClassOf ?o }")
-    assert len(rows) == 3
-    rows.sort()  # ensure consistent ordering of rows
-    assert rows[0] == (
-        "http://example.com/onto#AnotherConcept",
-        "http://www.w3.org/2002/07/owl#Thing",
-    )
-    assert rows[1] == (
-        "http://example.com/onto#MyConcept",
-        "http://www.w3.org/2002/07/owl#Thing",
-    )
-    assert rows[2] == (
-        "http://example.com/onto#Sum",
-        "http://www.w3.org/2002/07/owl#Thing",
-    )
+    try:
+        rows = store.query("SELECT ?s ?o WHERE { ?s rdfs:subClassOf ?o }")
+    except NotImplementedError:
+        pass
+    else:
+        assert len(rows) == 3
+        rows.sort()  # ensure consistent ordering of rows
+        assert rows[0] == (
+            "http://example.com/onto#AnotherConcept",
+            "http://www.w3.org/2002/07/owl#Thing",
+        )
+        assert rows[1] == (
+            "http://example.com/onto#MyConcept",
+            "http://www.w3.org/2002/07/owl#Thing",
+        )
+        assert rows[2] == (
+            "http://example.com/onto#Sum",
+            "http://www.w3.org/2002/07/owl#Thing",
+        )
 
 
 def test_backend_rdflib(expected_function_triplestore: str) -> None:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -32,6 +32,7 @@ with pytest.raises(TypeError):
 with pytest.raises(ValueError):
     split_iri("abc")
 
+
 # Test function_id()
 def f():
     """Function."""
@@ -78,6 +79,14 @@ assert parse_object("1") == Literal("1", datatype=XSD.integer)
 assert parse_object("-1") == Literal("-1", datatype=XSD.integer)
 assert parse_object("42") == Literal("42", datatype=XSD.integer)
 assert parse_object("3.14") == Literal("3.14", datatype=XSD.double)
+assert parse_object(".1") == Literal(".1", datatype=XSD.double)
+assert parse_object("1.") == Literal("1.", datatype=XSD.double)
+assert parse_object("1e10") == Literal("1e10", datatype=XSD.double)
+assert parse_object("1E10") == Literal("1E10", datatype=XSD.double)
+assert parse_object("1e+10") == Literal("1e+10", datatype=XSD.double)
+assert parse_object("1e-10") == Literal("1e-10", datatype=XSD.double)
+assert parse_object(".1e10") == Literal(".1e10", datatype=XSD.double)
+assert parse_object("1.e10") == Literal("1.e10", datatype=XSD.double)
 assert parse_object("abc") == Literal("abc", datatype=XSD.string)
 assert parse_object('"abc"@en') == Literal("abc", lang="en")
 assert parse_object(str(XSD)) == str(XSD)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -94,6 +94,9 @@ assert parse_object("2022-12-01 12:30") == Literal(
 assert parse_object("2022-12-01 12:30:30") == Literal(
     "2022-12-01 12:30:30", datatype=XSD.dateTime
 )
+assert parse_object("2022-12-01T12:30:30") == Literal(
+    "2022-12-01T12:30:30", datatype=XSD.dateTime
+)
 assert parse_object("2022-12-01 12:30:30.50") == Literal(
     "2022-12-01 12:30:30.50", datatype=XSD.dateTime
 )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -87,9 +87,29 @@ assert parse_object("1e+10") == Literal("1e+10", datatype=XSD.double)
 assert parse_object("1e-10") == Literal("1e-10", datatype=XSD.double)
 assert parse_object(".1e10") == Literal(".1e10", datatype=XSD.double)
 assert parse_object("1.e10") == Literal("1.e10", datatype=XSD.double)
+assert parse_object("2022-12-01") == Literal("2022-12-01", datatype=XSD.dateTime)
+assert parse_object("2022-12-01 12:30") == Literal(
+    "2022-12-01 12:30", datatype=XSD.dateTime
+)
+assert parse_object("2022-12-01 12:30:30") == Literal(
+    "2022-12-01 12:30:30", datatype=XSD.dateTime
+)
+assert parse_object("2022-12-01 12:30:30.50") == Literal(
+    "2022-12-01 12:30:30.50", datatype=XSD.dateTime
+)
+assert parse_object("2022-12-01 12:30:30Z") == Literal(
+    "2022-12-01 12:30:30Z", datatype=XSD.dateTime
+)
+assert parse_object("2022-12-01 12:30:30+01:00") == Literal(
+    "2022-12-01 12:30:30+01:00", datatype=XSD.dateTime
+)
 assert parse_object("abc") == Literal("abc", datatype=XSD.string)
 assert parse_object('"abc"@en') == Literal("abc", lang="en")
 assert parse_object(str(XSD)) == str(XSD)
 assert parse_object(XSD.int) == XSD.int
 assert parse_object(f'"42"^^{XSD.integer}') == Literal("42", datatype=XSD.integer)
+assert parse_object(f'"4.2"^^{XSD.double}') == Literal("4.2", datatype=XSD.double)
+
+# __FIXME__: parse_object() currently fails for the following cases:
+# assert parse_object(f'"42"^^{XSD.double}') == Literal("42", datatype=XSD.double)
 # assert parse_object(f'"42"^^{XSD.int}') == Literal("42", datatype=XSD.int)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,86 @@
+"""Test utils"""
+# pylint: disable=invalid-name
+import dlite
+import pytest
+
+from tripper import DCTERMS, RDFS, XSD, Literal
+from tripper.utils import (
+    en,
+    function_id,
+    infer_iri,
+    parse_literal,
+    parse_object,
+    split_iri,
+)
+
+# Test infer_iri()
+assert infer_iri(RDFS.subClassOf) == RDFS.subClassOf
+
+coll = dlite.Collection()
+assert infer_iri(coll.meta) == coll.meta.uri
+assert infer_iri(coll) == coll.uuid
+
+# Test split_iri()
+rdfs = str(RDFS)
+assert split_iri(RDFS.subClassOf) == (rdfs, "subClassOf")
+assert split_iri(rdfs) == (rdfs, "")
+dcterms = str(DCTERMS)
+assert split_iri(DCTERMS.author) == (dcterms, "author")
+assert split_iri(dcterms) == (dcterms, "")
+with pytest.raises(TypeError):
+    split_iri(3.14)
+with pytest.raises(ValueError):
+    split_iri("abc")
+
+# Test function_id()
+def f():
+    """Function."""
+    return 0
+
+
+def g():
+    """Function."""
+    return 0
+
+
+def h():
+    """Function."""
+    return 1
+
+
+fid1 = function_id(f)
+fid2 = function_id(f)
+assert fid2 == fid1
+fid3 = function_id(g)
+assert fid3 != fid1
+fid4 = function_id(h)
+assert fid4 != fid1
+assert fid4 != fid3
+
+
+# Test en()
+assert en("abc") == Literal("abc", lang="en")
+
+# test parse_literal()
+assert parse_literal("abc") == Literal("abc", datatype=XSD.string)
+assert parse_literal(True) == Literal("True", datatype=XSD.boolean)
+assert parse_literal(1) == Literal("1", datatype=XSD.inteter)
+assert parse_literal(3.14) == Literal("3.14", datatype=XSD.double)
+assert parse_literal(f'"3.14"^^{XSD.double}') == Literal("3.14", datatype=XSD.double)
+
+
+# test parse_object()
+assert parse_object("True") == Literal("True", datatype=XSD.boolean)
+assert parse_object("False") == Literal("False", datatype=XSD.boolean)
+assert parse_object("true") == Literal("true", datatype=XSD.string)
+assert parse_object("0") == Literal("0", datatype=XSD.integer)
+assert parse_object("1") == Literal("1", datatype=XSD.integer)
+assert parse_object("-1") == Literal("-1", datatype=XSD.integer)
+assert parse_object("42") == Literal("42", datatype=XSD.integer)
+assert parse_object("3.14") == Literal("3.14", datatype=XSD.double)
+assert parse_object("abc") == Literal("abc", datatype=XSD.string)
+assert parse_object('"abc"@en') == Literal("abc", lang="en")
+assert parse_object(str(XSD)) == str(XSD)
+assert parse_object(XSD.int) == XSD.int
+assert parse_object(f'"42"^^{XSD.integer}') == Literal("42", datatype=XSD.integer)
+# assert parse_object(f'"42"^^{XSD.int}') == Literal("42", datatype=XSD.int)

--- a/tripper/backends/collection.py
+++ b/tripper/backends/collection.py
@@ -1,0 +1,67 @@
+"""Backend for DLite collections.
+
+"""
+# pylint: disable=protected-access,invalid-name
+from typing import TYPE_CHECKING
+
+import dlite
+
+from tripper.literal import Literal
+from tripper.utils import parse_object
+
+if TYPE_CHECKING:  # pragma: no cover
+    from collections.abc import Sequence
+    from typing import Generator, List, Optional, Union
+
+    from tripper.triplestore import Triple
+
+
+class CollectionStrategy:
+    """Triplestore strategy for DLite collections.
+
+    Arguments:
+        base_iri: Unused.
+        database: Unused - collection does not support multiple databases.
+        collection: Optional collection from which to initialise the
+            triplestore from.
+    """
+
+    def __init__(
+        self,
+        base_iri: "Optional[str]" = None,
+        database: "Optional[str]" = None,
+        collection: "Optional[Union[dlite.Collection, str]]" = None,
+    ):
+        # pylint: disable=unused-argument
+        if collection is None:
+            self.collection = dlite.Collection()
+        elif isinstance(collection, str):
+            self.collection = dlite.get_instance(collection)
+            if self.collection.meta.uri != dlite.COLLECTION_ENTITY:
+                raise TypeError(
+                    f"expected '{collection}' to be a collection, was a "
+                    f"{self.collection.meta.uri}"
+                )
+        elif isinstance(collection, dlite.Collection):
+            self.collection = collection
+        else:
+            raise TypeError("`collection` should be None, string or a collection")
+
+    def triples(self, triple: "Triple") -> "Generator[Triple, None, None]":
+        """Returns a generator over matching triples."""
+        for s, p, o in self.collection.get_relations(*triple):
+            yield s, p, parse_object(o)
+
+    def add_triples(self, triples: "Sequence[Triple]"):
+        """Add a sequence of triples."""
+        for s, p, o in triples:
+            v = parse_object(o)
+            v_str = v.n3() if isinstance(v, Literal) else v
+            self.collection.add_relation(s, p, v_str)
+
+    def remove(self, triple: "Triple"):
+        """Remove all matching triples from the backend."""
+        s, p, o = triple
+        v = parse_object(o)
+        v_str = v.n3() if isinstance(v, Literal) else v
+        self.collection.remove_relations(s, p, v_str)

--- a/tripper/literal.py
+++ b/tripper/literal.py
@@ -79,9 +79,9 @@ class Literal(str):
         return string
 
     def __repr__(self) -> str:
-        lang = f", lang={self.lang!r}" if self.lang else ""
-        datatype = f", datatype={self.datatype!r}" if self.datatype else ""
-        return f"Literal({self!r}{lang}{datatype})"
+        lang = f", lang='{self.lang}'" if self.lang else ""
+        datatype = f", datatype='{self.datatype}'" if self.datatype else ""
+        return f"Literal('{self}'{lang}{datatype})"
 
     value = property(
         fget=lambda self: self.to_python(),

--- a/tripper/triplestore.py
+++ b/tripper/triplestore.py
@@ -30,7 +30,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from collections.abc import Mapping
     from typing import Callable, Dict, Generator, List, Optional, Tuple, Union
 
-    Triple = Tuple[Union[str, None], Union[str, None], Union[str, None]]
+    from tripper.utils import OptionalTriple, Triple
 
 
 # Regular expression matching a prefixed IRI

--- a/tripper/utils.py
+++ b/tripper/utils.py
@@ -171,7 +171,7 @@ def parse_object(object: "Union[str, Literal]") -> "Union[str, Literal]":
         }
         for pytype, datatype in types.items():
             try:
-                pytype(object)
+                pytype(object)  # type: ignore
             except ValueError:
                 pass
             else:

--- a/tripper/utils.py
+++ b/tripper/utils.py
@@ -165,11 +165,12 @@ def parse_object(object: "Union[str, Literal]") -> "Union[str, Literal]":
         if re.match(r"^[a-z]+://", object):
             return object
         types = {
-            int: XSD.integer,
-            float: XSD.double,
-            datetime.datetime.fromisoformat: XSD.dateTime,
+            XSD.integer: int,
+            XSD.int: int,
+            XSD.double: float,  # must come after int
+            XSD.dateTime: datetime.datetime.fromisoformat,
         }
-        for pytype, datatype in types.items():
+        for datatype, pytype in types.items():
             try:
                 pytype(object)  # type: ignore
             except ValueError:

--- a/tripper/utils.py
+++ b/tripper/utils.py
@@ -1,4 +1,6 @@
 """Utility functions."""
+# pylint: disable=invalid-name,redefined-builtin
+import datetime
 import hashlib
 import inspect
 import re
@@ -8,7 +10,12 @@ from tripper.literal import Literal
 from tripper.namespace import XSD
 
 if TYPE_CHECKING:  # pragma: no cover
-    from typing import Any, Callable, Tuple
+    from typing import Any, Callable, Tuple, Union
+
+    OptionalTriple = Tuple[
+        Union[str, None], Union[str, None], Union[str, Literal, None]
+    ]
+    Triple = Tuple[str, str, Union[str, Literal]]
 
 
 def infer_iri(obj):
@@ -29,7 +36,7 @@ def infer_iri(obj):
             return properties["uri"]
         if "uuid" in properties and properties["uuid"]:
             return properties["uuid"]
-    raise TypeError("cannot infer IRI from object {obj!r}")
+    raise TypeError(f"cannot infer IRI from object: {obj!r}")
 
 
 def split_iri(iri: str) -> "Tuple[str, str]":
@@ -133,3 +140,41 @@ def parse_literal(literal: "Any") -> "Literal":
                 pass
 
     raise ValueError("cannot parse {literal=}")
+
+
+def parse_object(object: "Union[str, Literal]") -> "Union[str, Literal]":
+    """Applies heuristics to parse RDF object `object` to an IRI or literal.
+
+    The following heuristics is performed (in the given order):
+    - If `object` is a Literal, it is returned.
+    - If `object` is a string and
+      - starts with a scheme, it is asumed to be an IRI and returned.
+      - can be converted to a float, int or datetime, return it
+        converted to a literal of the corresponding type.
+      - it is a valid n3 representation, return it as the given type.
+      - otherwise, return it as a xsd:string literal.
+    - Otherwise, raise an ValueError.
+
+    Returns
+        A string if `object` is considered to be an IRI, otherwise a
+        literal.
+    """
+    if isinstance(object, Literal):
+        return object
+    if isinstance(object, str):
+        if re.match(r"^[a-z]+://", object):
+            return object
+        types = {
+            int: XSD.integer,
+            float: XSD.double,
+            datetime.datetime.fromisoformat: XSD.dateTime,
+        }
+        for pytype, datatype in types.items():
+            try:
+                pytype(object)
+            except ValueError:
+                pass
+            else:
+                return Literal(object, datatype=datatype)
+        return parse_literal(object)
+    raise ValueError("`object` should be a literal or a string.")


### PR DESCRIPTION
Closes #41 

Simple backend providing a tripper interface to DLite collections. Will be used by oteapi when DLite is chooses as interoperability platform.

This PR also include tests for utils.py - they are written as a script since they are so simple that test isolation via pytest is not needed. 

Note this is a minimal implementation. Support for prefixes should be added in follow-up PRs.

Right now all triples are stored written out completely, but for the user of dlite, I guess it would be easier if the IRIs stored in the collection would be prefixed. This is a topic for a later PR, though.
