### PR TITLE
Fix utils.parse_object()

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -112,7 +112,5 @@ assert parse_object(str(XSD)) == str(XSD)
 assert parse_object(XSD.int) == XSD.int
 assert parse_object(f'"42"^^{XSD.integer}') == Literal("42", datatype=XSD.integer)
 assert parse_object(f'"4.2"^^{XSD.double}') == Literal("4.2", datatype=XSD.double)
-
-# __FIXME__: parse_object() currently fails for the following cases:
-# assert parse_object(f'"42"^^{XSD.double}') == Literal("42", datatype=XSD.double)
-# assert parse_object(f'"42"^^{XSD.int}') == Literal("42", datatype=XSD.int)
+assert parse_object(f'"42"^^{XSD.double}') == Literal("42.0", datatype=XSD.double)
+assert parse_object(f'"42"^^{XSD.int}') == Literal("42", datatype=XSD.int)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -65,15 +65,15 @@ assert en("abc") == Literal("abc", lang="en")
 # test parse_literal()
 assert parse_literal("abc") == Literal("abc", datatype=XSD.string)
 assert parse_literal(True) == Literal("True", datatype=XSD.boolean)
-assert parse_literal(1) == Literal("1", datatype=XSD.inteter)
+assert parse_literal(1) == Literal("1", datatype=XSD.integer)
 assert parse_literal(3.14) == Literal("3.14", datatype=XSD.double)
 assert parse_literal(f'"3.14"^^{XSD.double}') == Literal("3.14", datatype=XSD.double)
 
 
 # test parse_object()
-assert parse_object("True") == Literal("True", datatype=XSD.boolean)
-assert parse_object("False") == Literal("False", datatype=XSD.boolean)
-assert parse_object("true") == Literal("true", datatype=XSD.string)
+assert parse_object("true") == Literal("true", datatype=XSD.boolean)
+assert parse_object("false") == Literal("false", datatype=XSD.boolean)
+assert parse_object("True") == Literal("True", datatype=XSD.string)
 assert parse_object("0") == Literal("0", datatype=XSD.integer)
 assert parse_object("1") == Literal("1", datatype=XSD.integer)
 assert parse_object("-1") == Literal("-1", datatype=XSD.integer)
@@ -97,12 +97,13 @@ assert parse_object("2022-12-01 12:30:30") == Literal(
 assert parse_object("2022-12-01T12:30:30") == Literal(
     "2022-12-01T12:30:30", datatype=XSD.dateTime
 )
-assert parse_object("2022-12-01 12:30:30.50") == Literal(
-    "2022-12-01 12:30:30.50", datatype=XSD.dateTime
+assert parse_object("2022-12-01 12:30:30.500") == Literal(
+    "2022-12-01 12:30:30.500", datatype=XSD.dateTime
 )
-assert parse_object("2022-12-01 12:30:30Z") == Literal(
-    "2022-12-01 12:30:30Z", datatype=XSD.dateTime
-)
+# Removed in Python 3.10
+# assert parse_object("2022-12-01 12:30:30Z") == Literal(
+#    "2022-12-01 12:30:30Z", datatype=XSD.dateTime
+# )
 assert parse_object("2022-12-01 12:30:30+01:00") == Literal(
     "2022-12-01 12:30:30+01:00", datatype=XSD.dateTime
 )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -100,7 +100,7 @@ assert parse_object("2022-12-01T12:30:30") == Literal(
 assert parse_object("2022-12-01 12:30:30.500") == Literal(
     "2022-12-01 12:30:30.500", datatype=XSD.dateTime
 )
-# Removed in Python 3.10
+# Format not supported in Python < 3.11
 # assert parse_object("2022-12-01 12:30:30Z") == Literal(
 #    "2022-12-01 12:30:30Z", datatype=XSD.dateTime
 # )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -46,8 +46,7 @@ else:
         """An entity."""
 
         # pylint: disable=unsubscriptable-object
-
-        uri: AnyUrl = Field(..., description="Unique URI identifying the entity.")
+        identity: AnyUrl = Field(..., description="Unique URI identifying the entity.")
         description: str = Field("", description="A description of the entity.")
         dimensions: Optional[dict[str, str]] = Field(
             None, description="Dict mapping dimension names to descriptions."
@@ -55,7 +54,7 @@ else:
         properties: dict[str, Property] = Field(..., description="Dict of properties.")
 
     user = Entity(
-        uri="http://onto-ns.com/meta/0.1/User",
+        identity="http://onto-ns.com/meta/0.1/User",
         properties={
             "username": Property(type=str, description="username"),
             "quota": Property(type=float, unit="GB", description="User quota"),

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -20,7 +20,8 @@ coll = dlite.Collection()
 assert infer_iri(coll.meta) == coll.meta.uri
 assert infer_iri(coll) == coll.uuid
 
-# We have no dependencies on pydantic, hence don't assume that it is installed
+# We have no dependencies on pydantic, hence don't assume that it is installed.
+# But if it is, infer_iri() should be able to infer IRIs from SOFT7 datamodels.
 try:
     from pydantic import AnyUrl, BaseModel, Field
 except ImportError:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -31,6 +31,8 @@ else:
     class Property(BaseModel):
         """A property."""
 
+        # pylint: disable=unsubscriptable-object
+        # Yet another pylint bug, see https://github.com/PyCQA/pylint/issues/1498
         type: Any = Field(..., description="Valid type name.")
         shape: Optional[list[str]] = Field(
             None, description="List of dimension expressions."
@@ -42,6 +44,8 @@ else:
 
     class Entity(BaseModel):
         """An entity."""
+
+        # pylint: disable=unsubscriptable-object
 
         uri: AnyUrl = Field(..., description="Unique URI identifying the entity.")
         description: str = Field("", description="A description of the entity.")

--- a/tripper/literal.py
+++ b/tripper/literal.py
@@ -102,7 +102,7 @@ class Literal(str):
         return string
 
     def __hash__(self):
-        return hash((self, self.lang, self.datatype))
+        return hash((str(self), self.lang, self.datatype))
 
     def __eq__(self, other):
         if isinstance(other, Literal):
@@ -111,7 +111,7 @@ class Literal(str):
                 and self.lang == other.lang
                 and self.datatype == other.datatype
             )
-        return False
+        return str(self) == str(other)
 
     def __repr__(self) -> str:
         lang = f", lang='{self.lang}'" if self.lang else ""

--- a/tripper/literal.py
+++ b/tripper/literal.py
@@ -101,6 +101,18 @@ class Literal(str):
                 string.datatype = None
         return string
 
+    def __hash__(self):
+        return hash((self, self.lang, self.datatype))
+
+    def __eq__(self, other):
+        if isinstance(other, Literal):
+            return (
+                str(self) == str(other)
+                and self.lang == other.lang
+                and self.datatype == other.datatype
+            )
+        return False
+
     def __repr__(self) -> str:
         lang = f", lang='{self.lang}'" if self.lang else ""
         datatype = f", datatype='{self.datatype}'" if self.datatype else ""

--- a/tripper/literal.py
+++ b/tripper/literal.py
@@ -3,7 +3,7 @@ import warnings
 from datetime import datetime
 from typing import TYPE_CHECKING
 
-from tripper.namespace import OWL, RDF, RDFS, XSD
+from tripper.namespace import RDF, RDFS, XSD
 
 if TYPE_CHECKING:  # pragma: no cover
     from typing import Any, Optional, Union
@@ -13,15 +13,14 @@ class Literal(str):
     """A literal RDF value.
 
     Arguments:
-        value (Union[datetime, bytes, bytearray, bool, int, float, str]): The literal
-            value. See the `datatypes` class attribute for valid supported data types.
-            A localised string is provided as a string with `lang` set to a language
-            code.
-        lang (Optional[str]): A standard language code, like "en", "no", etc. Implies
-            that the `value` is a localised string.
-        datatype (Any): Explicit specification of the type of `value`. Should not be
-            combined with `lang`.
-
+        value (Union[datetime, bytes, bytearray, bool, int, float, str]):
+            The literal value. See the `datatypes` class attribute for valid
+            supported data types.  A localised string is provided as a string
+            with `lang` set to a language code.
+        lang (Optional[str]): A standard language code, like "en", "no", etc.
+            Implies that the `value` is a localised string.
+        datatype (Any): Explicit specification of the type of `value`. Should
+            not be combined with `lang`.
     """
 
     lang: "Union[str, None]"
@@ -30,13 +29,37 @@ class Literal(str):
     # Note that the order of datatypes matters - it is used by
     # utils.parse_literal() when inferring the datatype of a literal.
     datatypes = {
-        datetime: XSD.dateTime,
-        bytes: XSD.hexBinary,
-        bytearray: XSD.hexBinary,
-        bool: XSD.boolean,
-        int: XSD.integer,
-        float: XSD.double,
-        str: XSD.string,
+        datetime: (XSD.dateTime,),
+        bytes: (XSD.hexBinary,),
+        bytearray: (XSD.hexBinary,),
+        bool: (XSD.boolean,),
+        int: (
+            XSD.integer,
+            XSD.int,
+            XSD.short,
+            XSD.long,
+            XSD.nonPositiveInteger,
+            XSD.negativeInteger,
+            XSD.unsignedInt,
+            XSD.unsignedShort,
+            XSD.unsignedLong,
+            XSD.byte,
+            XSD.unsignedByte,
+        ),
+        float: (XSD.double, XSD.decimal, XSD.dateTimeStamp, XSD.real, XSD.rational),
+        str: (
+            XSD.string,
+            RDF.PlainLiteral,
+            RDF.XMLLiteral,
+            RDFS.Literal,
+            XSD.anyURI,
+            XSD.language,
+            XSD.Name,
+            XSD.NMName,
+            XSD.normalizedString,
+            XSD.token,
+            XSD.NMTOKEN,
+        ),
     }
 
     def __new__(
@@ -54,7 +77,7 @@ class Literal(str):
         else:
             string.lang = None
             if datatype:
-                string.datatype = cls.datatypes.get(datatype, datatype)
+                string.datatype = cls.datatypes.get(datatype, (datatype,))[0]
             elif isinstance(value, str):
                 string.datatype = None
             elif isinstance(value, bool):
@@ -95,46 +118,15 @@ class Literal(str):
 
         if self.datatype == XSD.boolean:
             value = False if self == "False" else bool(self)
-        elif self.datatype in (
-            XSD.integer,
-            XSD.int,
-            XSD.short,
-            XSD.long,
-            XSD.nonPositiveInteger,
-            XSD.negativeInteger,
-            XSD.nonNegativeInteger,
-            XSD.unsignedInt,
-            XSD.unsignedShort,
-            XSD.unsignedLong,
-            XSD.byte,
-            XSD.unsignedByte,
-        ):
+        elif self.datatype in self.datatypes[int]:
             value = int(self)
-        elif self.datatype in (
-            XSD.double,
-            XSD.decimal,
-            XSD.dataTimeStamp,
-            OWL.real,
-            OWL.rational,
-        ):
+        elif self.datatype in self.datatypes[float]:
             value = float(self)
         elif self.datatype == XSD.hexBinary:
             value = self.encode()
         elif self.datatype == XSD.dateTime:
             value = datetime.fromisoformat(self)
-        elif self.datatype and self.datatype not in (
-            RDF.PlainLiteral,
-            RDF.XMLLiteral,
-            RDFS.Literal,
-            XSD.anyURI,
-            XSD.language,
-            XSD.Name,
-            XSD.NMName,
-            XSD.normalizedString,
-            XSD.string,
-            XSD.token,
-            XSD.NMTOKEN,
-        ):
+        elif self.datatype and self.datatype not in self.datatypes[str]:
             warnings.warn(f"unknown datatype: {self.datatype} - assuming string")
         return value
 

--- a/tripper/namespace.py
+++ b/tripper/namespace.py
@@ -159,6 +159,12 @@ class Namespace:
     def __add__(self, other):
         return self._iri + str(other)
 
+    def __hash__(self):
+        return hash(self._iri)
+
+    def __eq__(self, other):
+        return self._iri == str(other)
+
 
 # Pre-defined namespaces
 XML = Namespace("http://www.w3.org/XML/1998/namespace")

--- a/tripper/utils.py
+++ b/tripper/utils.py
@@ -22,20 +22,27 @@ def infer_iri(obj):
     """Return IRI of the individual that stands for object `obj`."""
     if isinstance(obj, str):
         iri = obj
-    elif hasattr(obj, "uri") and obj.uri:
+    elif hasattr(obj, "uri") and isinstance(obj.uri, str):
         # dlite.Metadata or dataclass (or instance with uri)
         iri = obj.uri
     elif hasattr(obj, "uuid") and obj.uuid:
         # dlite.Instance or dataclass
-        iri = obj.uuid
+        iri = str(obj.uuid)
     elif hasattr(obj, "schema") and callable(obj.schema):
         # pydantic.BaseModel
-        schema = obj.schema()
-        properties = schema["properties"]
-        if "uri" in properties and properties["uri"]:
-            iri = properties["uri"]
-        if "uuid" in properties and properties["uuid"]:
-            iri = properties["uuid"]
+        if hasattr(obj, "identity") and isinstance(obj.identity, str):
+            # soft7 pydantic model
+            iri = obj.identity
+        else:
+            # pydantic instance
+            schema = obj.schema()
+            properties = schema["properties"]
+            if "uri" in properties and isinstance(properties["uri"], str):
+                iri = properties["uri"]
+            if "identity" in properties and isinstance(properties["identity"], str):
+                iri = properties["identity"]
+            if "uuid" in properties and properties["uuid"]:
+                iri = str(properties["uuid"])
     else:
         raise TypeError(f"cannot infer IRI from object: {obj!r}")
     return str(iri)

--- a/tripper/utils.py
+++ b/tripper/utils.py
@@ -21,22 +21,24 @@ if TYPE_CHECKING:  # pragma: no cover
 def infer_iri(obj):
     """Return IRI of the individual that stands for object `obj`."""
     if isinstance(obj, str):
-        return obj
-    if hasattr(obj, "uri") and obj.uri:
+        iri = obj
+    elif hasattr(obj, "uri") and obj.uri:
         # dlite.Metadata or dataclass (or instance with uri)
-        return obj.uri
-    if hasattr(obj, "uuid") and obj.uuid:
+        iri = obj.uri
+    elif hasattr(obj, "uuid") and obj.uuid:
         # dlite.Instance or dataclass
-        return obj.uuid
-    if hasattr(obj, "schema") and callable(obj.schema):
+        iri = obj.uuid
+    elif hasattr(obj, "schema") and callable(obj.schema):
         # pydantic.BaseModel
         schema = obj.schema()
         properties = schema["properties"]
         if "uri" in properties and properties["uri"]:
-            return properties["uri"]
+            iri = properties["uri"]
         if "uuid" in properties and properties["uuid"]:
-            return properties["uuid"]
-    raise TypeError(f"cannot infer IRI from object: {obj!r}")
+            iri = properties["uuid"]
+    else:
+        raise TypeError(f"cannot infer IRI from object: {obj!r}")
+    return str(iri)
 
 
 def split_iri(iri: str) -> "Tuple[str, str]":

--- a/tripper/utils.py
+++ b/tripper/utils.py
@@ -171,7 +171,7 @@ def parse_object(obj: "Union[str, Literal]") -> "Union[str, Literal]":
             return obj
         if obj in ("true", "false"):  # boolean
             return Literal(obj, datatype=XSD.boolean)
-        if re.match(r"^\s*[+-]?\d+\s*^", obj):  # integer
+        if re.match(r"^\s*[+-]?\d+\s*$", obj):  # integer
             return Literal(obj, datatype=XSD.integer)
         if check(float, obj, ValueError):  #  float
             return Literal(obj, datatype=XSD.double)

--- a/tripper/utils.py
+++ b/tripper/utils.py
@@ -161,8 +161,9 @@ def parse_object(obj: "Union[str, Literal]") -> "Union[str, Literal]":
     The following heuristics is performed (in the given order):
     - If `obj` is a Literal, it is returned.
     - If `obj` is a string and
+      - starts with "_:", it is assumed to be a blank node and returned.
       - starts with a scheme, it is asumed to be an IRI and returned.
-      - can be converted to a boolean, int, float or datetime, return it
+      - can be converted to a float, int or datetime, it is returned.
         converted to a literal of the corresponding type.
       - it is a valid n3 representation, return it as the given type.
       - otherwise, return it as a xsd:string literal.
@@ -176,7 +177,7 @@ def parse_object(obj: "Union[str, Literal]") -> "Union[str, Literal]":
     if isinstance(obj, Literal):
         return obj
     if isinstance(obj, str):
-        if re.match(r"^[a-z]+://", obj):  # IRI
+        if obj.startswith("_:") or re.match(r"^[a-z]+://", obj):  # IRI
             return obj
         if obj in ("true", "false"):  # boolean
             return Literal(obj, datatype=XSD.boolean)

--- a/tripper/utils.py
+++ b/tripper/utils.py
@@ -97,7 +97,9 @@ def parse_literal(literal: "Any") -> "Literal":
     if not isinstance(literal, str):
         if isinstance(literal, tuple(Literal.datatypes)):
             return Literal(
-                literal, lang=lang, datatype=Literal.datatypes.get(type(literal))
+                literal,
+                lang=lang,
+                datatype=Literal.datatypes.get(type(literal))[0],  # type: ignore
             )
         TypeError(f"unsupported literal type: {type(literal)}")
 
@@ -124,7 +126,9 @@ def parse_literal(literal: "Any") -> "Literal":
 
     if lang or datatype:
         if datatype:
-            types = {v: k for k, v in Literal.datatypes.items()}
+            types = {}
+            for pytype, datatypes in Literal.datatypes.items():
+                types.update({t: pytype for t in datatypes})
             type_ = types[datatype]
             try:
                 value = type_(value)
@@ -132,50 +136,61 @@ def parse_literal(literal: "Any") -> "Literal":
                 pass
         return Literal(value, lang=lang, datatype=datatype)
 
-    for type_, datatype in Literal.datatypes.items():
+    for type_, datatypes in Literal.datatypes.items():
         if type_ is not bool:
             try:
-                return Literal(type_(literal), lang=lang, datatype=datatype)
+                return Literal(type_(literal), lang=lang, datatype=datatypes[0])
             except (ValueError, TypeError):
                 pass
 
-    raise ValueError("cannot parse {literal=}")
+    raise ValueError(f'cannot parse literal "{literal}"')
 
 
-def parse_object(object: "Union[str, Literal]") -> "Union[str, Literal]":
-    """Applies heuristics to parse RDF object `object` to an IRI or literal.
+def parse_object(obj: "Union[str, Literal]") -> "Union[str, Literal]":
+    """Applies heuristics to parse RDF object `obj` to an IRI or literal.
 
     The following heuristics is performed (in the given order):
-    - If `object` is a Literal, it is returned.
-    - If `object` is a string and
+    - If `obj` is a Literal, it is returned.
+    - If `obj` is a string and
       - starts with a scheme, it is asumed to be an IRI and returned.
-      - can be converted to a float, int or datetime, return it
+      - can be converted to a boolean, int, float or datetime, return it
         converted to a literal of the corresponding type.
       - it is a valid n3 representation, return it as the given type.
       - otherwise, return it as a xsd:string literal.
     - Otherwise, raise an ValueError.
 
     Returns
-        A string if `object` is considered to be an IRI, otherwise a
+        A string if `obj` is considered to be an IRI, otherwise a
         literal.
     """
-    if isinstance(object, Literal):
-        return object
-    if isinstance(object, str):
-        if re.match(r"^[a-z]+://", object):
-            return object
-        types = {
-            XSD.integer: int,
-            XSD.int: int,
-            XSD.double: float,  # must come after int
-            XSD.dateTime: datetime.datetime.fromisoformat,
-        }
-        for datatype, pytype in types.items():
-            try:
-                pytype(object)  # type: ignore
-            except ValueError:
-                pass
-            else:
-                return Literal(object, datatype=datatype)
-        return parse_literal(object)
-    raise ValueError("`object` should be a literal or a string.")
+    # pylint: disable=too-many-return-statements
+    if isinstance(obj, Literal):
+        return obj
+    if isinstance(obj, str):
+        if re.match(r"^[a-z]+://", obj):  # IRI
+            return obj
+        if obj in ("true", "false"):  # boolean
+            return Literal(obj, datatype=XSD.boolean)
+        if re.match(r"^\s*[+-]?\d+\s*^", obj):  # integer
+            return Literal(obj, datatype=XSD.integer)
+        if check(float, obj, ValueError):  #  float
+            return Literal(obj, datatype=XSD.double)
+        if check(datetime.datetime.fromisoformat, obj, ValueError):  #  datetime
+            return Literal(obj, datatype=XSD.dateTime)
+        return parse_literal(obj)
+    raise ValueError("`obj` should be a literal or a string.")
+
+
+def check(func: "Callable", s: str, exceptions) -> bool:
+    """Help function that returns true if `func(s)` does not raise an exception.
+
+    False is returned if `func(s)` raises an exception listed in `exceptions`.
+    Otherwise the exception is propagated.
+    """
+    # Note that the missing type hint on `exceptions` is deliberately, see
+    # https://peps.python.org/pep-0484/#exceptions
+    try:
+        func(s)
+    except exceptions:
+        return False
+    return True


### PR DESCRIPTION
Closes #45 

General cleanup
- Fixing failing tests by improved generality of parse_literal() and parse_object().
- Added `__eq__()` and `__hash__()` methods to Literal. The `__eq__()` method is required for proper testing...
- Reduced code duplication.
- Hopefully also addressed the comments by @quaat  in PR #44
