### PR TITLE
Separated `base_iri` argument from `triplestore_url` in rdflib backend

### DIFF
--- a/tripper/backends/rdflib.py
+++ b/tripper/backends/rdflib.py
@@ -42,12 +42,11 @@ class RdflibStrategy:
     """Triplestore strategy for rdflib.
 
     Arguments:
-        base_iri: If given, initialise the triplestore from this storage.
-            When `close()` is called, the storage will be overwritten
-            with the current content of the triplestore.
+        base_iri: Unused by this backend.
         database: Unused - rdflib does not support multiple databases.
-        triplestore_url: Alternative URL to the underlying ontology if
-            `base_iri` is not resolvable.  Defaults to `base_iri`.
+        triplestore_url: If given, initialise the triplestore from this
+            storage.  When `close()` is called, the storage will be
+            overwritten with the current content of the triplestore.
         format: Format of storage specified with `base_iri`.
     """
 
@@ -60,8 +59,7 @@ class RdflibStrategy:
     ) -> None:
         # pylint: disable=unused-argument
         self.graph = Graph()
-        self.base_iri = base_iri
-        self.triplestore_url = triplestore_url if triplestore_url else base_iri
+        self.triplestore_url = triplestore_url
         if self.triplestore_url is not None:
             if format is None:
                 format = guess_format(self.triplestore_url)

--- a/tripper/backends/rdflib.py
+++ b/tripper/backends/rdflib.py
@@ -20,6 +20,7 @@ from rdflib import URIRef
 from rdflib.util import guess_format
 
 from tripper import Literal
+from tripper.utils import UnusedArgumentWarning
 
 if TYPE_CHECKING:  # pragma: no cover
     from collections.abc import Sequence
@@ -64,7 +65,11 @@ class RdflibStrategy:
         triplestore_url: "Optional[str]" = None,
         format: "Optional[str]" = None,  # pylint: disable=redefined-builtin
     ) -> None:
-        # pylint: disable=unused-argument
+        if base_iri:
+            warnings.warn("base_iri", UnusedArgumentWarning, stacklevel=2)
+        if database:
+            warnings.warn("database", UnusedArgumentWarning, stacklevel=2)
+
         self.graph = Graph()
         self.triplestore_url = triplestore_url
         if self.triplestore_url is not None:

--- a/tripper/utils.py
+++ b/tripper/utils.py
@@ -18,6 +18,10 @@ if TYPE_CHECKING:  # pragma: no cover
     Triple = Tuple[str, str, Union[str, Literal]]
 
 
+class UnusedArgumentWarning(Warning):
+    """Argument is unused."""
+
+
 def infer_iri(obj):
     """Return IRI of the individual that stands for object `obj`."""
     if isinstance(obj, str):


### PR DESCRIPTION
Before gave rdflib the `base_iri` argument an additional meaning not documented in Triplestore.__init__(). This is now taken over by the `triplestore_url` argument.
