### PR TITLE
Commented out __hash__() and __eq__() methods from Literal.

### DIFF
--- a/tripper/literal.py
+++ b/tripper/literal.py
@@ -101,17 +101,17 @@ class Literal(str):
                 string.datatype = None
         return string
 
-    def __hash__(self):
-        return hash((str(self), self.lang, self.datatype))
+    # def __hash__(self):
+    #     return hash((str(self), self.lang, self.datatype))
 
-    def __eq__(self, other):
-        if isinstance(other, Literal):
-            return (
-                str(self) == str(other)
-                and self.lang == other.lang
-                and self.datatype == other.datatype
-            )
-        return str(self) == str(other)
+    # def __eq__(self, other):
+    #     if isinstance(other, Literal):
+    #         return (
+    #             str(self) == str(other)
+    #             and self.lang == other.lang
+    #             and self.datatype == other.datatype
+    #         )
+    #     return str(self) == str(other)
 
     def __repr__(self) -> str:
         lang = f", lang='{self.lang}'" if self.lang else ""

--- a/tripper/literal.py
+++ b/tripper/literal.py
@@ -101,6 +101,12 @@ class Literal(str):
                 string.datatype = None
         return string
 
+    # These two methods are commeted out for now because they cause
+    # the DLite example/mapping/mappingfunc.py example to fail.
+    #
+    # It seems that these methods cause the datatype be changed to
+    # an "h" in some relations added by the add_function() method.
+
     # def __hash__(self):
     #     return hash((str(self), self.lang, self.datatype))
 


### PR DESCRIPTION
This fixes the issues in https://github.com/SINTEF/dlite/pull/375

We still have to understand exactly why adding `__hash__()` and `__eq__()` creates an issue. It seems to change the datatype of some literals...
