### PR TITLE
Generate mapping routes from subclasses of Value and MappingStep

### DIFF
--- a/tests/test_triplestore.py
+++ b/tests/test_triplestore.py
@@ -51,6 +51,7 @@ def test_triplestore(
         expects=(EX.MyConcept, EX.AnotherConcept),
         returns=EX.Sum,
         base_iri=EX,
+        standard="fno",
     )
 
     try:

--- a/tripper/mappings/__init__.py
+++ b/tripper/mappings/__init__.py
@@ -1,2 +1,2 @@
 """Sub-package for working with mappings."""
-from .mappings import mapping_routes
+from .mappings import MappingStep, Value, mapping_routes

--- a/tripper/triplestore.py
+++ b/tripper/triplestore.py
@@ -570,7 +570,7 @@ class Triplestore:
         expects: "Union[str, Sequence, Mapping]" = (),
         returns: "Union[str, Sequence]" = (),
         base_iri: "Optional[str]" = None,
-        standard: str = "fno",
+        standard: str = "emmo",
         cost: "Optional[Union[float, Callable]]" = None,
     ):
         """Inspect function and add triples describing it to the triplestore.


### PR DESCRIPTION
Added two new arguments to mapping_routes() such that we can generate mapping routes based on custom subclasses of Value and MappingStep.