### PR TITLE
Fixed parsing rdf:HTML literals with the rdflib backend

### DIFF
--- a/tripper/backends/rdflib.py
+++ b/tripper/backends/rdflib.py
@@ -20,7 +20,7 @@ from rdflib import URIRef
 from rdflib.util import guess_format
 
 from tripper import Literal
-from tripper.utils import UnusedArgumentWarning
+from tripper.utils import UnusedArgumentWarning, parse_literal
 
 if TYPE_CHECKING:  # pragma: no cover
     from collections.abc import Sequence
@@ -86,13 +86,7 @@ class RdflibStrategy:
             yield (
                 str(s),
                 str(p),
-                Literal(
-                    o.value,
-                    lang=o.language,
-                    datatype=str(o.datatype) if o.datatype else o.datatype,
-                )
-                if isinstance(o, rdflibLiteral)
-                else str(o),
+                parse_literal(o) if isinstance(o, rdflibLiteral) else str(o),
             )
 
     def add_triples(self, triples: "Sequence[Triple]"):

--- a/tripper/literal.py
+++ b/tripper/literal.py
@@ -49,6 +49,7 @@ class Literal(str):
         float: (XSD.double, XSD.decimal, XSD.dateTimeStamp, XSD.real, XSD.rational),
         str: (
             XSD.string,
+            RDF.HTML,
             RDF.PlainLiteral,
             RDF.XMLLiteral,
             RDFS.Literal,


### PR DESCRIPTION
# Description:
Ensure that the rdflib backend correctly parses rdf.HTML literals.

## Type of change:
<!-- Put an `x` in the box that applies. -->
- [x] Bug fix.
- [ ] New feature.
- [ ] Documentation update.

## Checklist for the reviewer:
<!-- Put an `x` in the boxes that apply. These can be filled by reviewer after the PR is created. -->

This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
