### PR TITLE
Fix issue with entry points for Python 3.6 and 3.7

### DIFF
--- a/tests/backends/dummy.py
+++ b/tests/backends/dummy.py
@@ -1,0 +1,19 @@
+"""Dummy tripper backend for testing loading a custom backend."""
+# pylint: disable=unused-argument
+
+
+class DummyStrategy:
+    """Dummy strategy."""
+
+    def __init__(self, base_iri=None, **kwargs):
+        """Initialise triplestore."""
+
+    def triples(self, triple):
+        """Returns a generator over matching triples."""
+        return ((s, p, o) for s, p, o in ("abc", "def", "ghi"))
+
+    def d_trioles(self, triples):
+        """Add a sequence of triples."""
+
+    def remove(self, triple):
+        """Remove all matching triples."""

--- a/tests/test_custom_backend.py
+++ b/tests/test_custom_backend.py
@@ -3,4 +3,8 @@ from tripper import Triplestore
 
 # Test relative import
 ts = Triplestore(backend="backends.dummy", package="backends")
-assert list(ts.triples()) == [("a", "b", "c"), ("d", "e", "f"), ("g", "h", "i")]
+assert list(ts.triples()) == [
+    ("a", "b", "c"),
+    ("d", "e", "f"),
+    ("g", "h", "i"),
+]

--- a/tests/test_custom_backend.py
+++ b/tests/test_custom_backend.py
@@ -4,8 +4,3 @@ from tripper import Triplestore
 # Test relative import
 ts = Triplestore(backend="backends.dummy", package="backends")
 assert list(ts.triples()) == [("a", "b", "c"), ("d", "e", "f"), ("g", "h", "i")]
-
-
-# Test entry point
-ts2 = Triplestore(backend="backends.dummy", package="backends")
-assert list(ts.triples()) == [("a", "b", "c"), ("d", "e", "f"), ("g", "h", "i")]

--- a/tests/test_custom_backend.py
+++ b/tests/test_custom_backend.py
@@ -1,0 +1,11 @@
+"""Test custom plugin."""
+from tripper import Triplestore
+
+# Test relative import
+ts = Triplestore(backend="backends.dummy", package="backends")
+assert list(ts.triples()) == [("a", "b", "c"), ("d", "e", "f"), ("g", "h", "i")]
+
+
+# Test entry point
+ts2 = Triplestore(backend="backends.dummy", package="backends")
+assert list(ts.triples()) == [("a", "b", "c"), ("d", "e", "f"), ("g", "h", "i")]

--- a/tripper/interface.py
+++ b/tripper/interface.py
@@ -10,7 +10,7 @@ else:
 
 if TYPE_CHECKING:  # pragma: no cover
     from collections.abc import Sequence
-    from typing import Generator
+    from typing import Generator, Optional
 
     from tripper.triplestore import Triple
 
@@ -22,14 +22,6 @@ class ITriplestore(Protocol):
     may also implement the following optional methods:
 
     ```python
-
-    def __init__(self, base_iri: str = None, **kwargs):
-        """Initialise triplestore.
-
-        Arguments:
-            base_iri: Optional base IRI to initiate the triplestore from.
-            kwargs: Additional keyword arguments passed to the backend.
-        """
 
     def parse(
             self,
@@ -153,6 +145,14 @@ class ITriplestore(Protocol):
 
     ```
     '''
+
+    def __init__(self, base_iri: "Optional[str]" = None, **kwargs):
+        """Initialise triplestore.
+
+        Arguments:
+            base_iri: Optional base IRI to initiate the triplestore from.
+            kwargs: Additional keyword arguments passed to the backend.
+        """
 
     def triples(self, triple: "Triple") -> "Generator":
         """Returns a generator over matching triples.

--- a/tripper/triplestore.py
+++ b/tripper/triplestore.py
@@ -129,12 +129,13 @@ class Triplestore:
                 method.
 
         """
+        backend_name = backend.rsplit(".", 1)[-1]
         module = self._load_backend(backend, package)
-        cls = getattr(module, f"{backend.title()}Strategy")
+        cls = getattr(module, f"{backend_name.title()}Strategy")
         self.base_iri = base_iri
         self.namespaces: "Dict[str, Namespace]" = {}
         self.closed = False
-        self.backend_name = backend
+        self.backend_name = backend_name
         self.backend = cls(base_iri=base_iri, database=database, **kwargs)
 
         # Keep functions in the triplestore for convienence even though
@@ -163,13 +164,11 @@ class Triplestore:
             return importlib.import_module(backend, package)
 
         # Installed backend package
-        if (3, 8) <= sys.version_info < (3, 10):
-            # Fallback for Python 3.8 and 3.9
+        if sys.version_info < (3, 10):
+            # Fallback for Python < 3.10
             eps = entry_points().get("tripper.backends", ())
         else:
-            # New entry_point interface from Python 3.10+, which is also
-            # implemented in the importlib_metadata backport for Python 3.6
-            # and 3.7.
+            # New entry_point interface from Python 3.10+
             eps = entry_points(group="tripper.backends")
         for entry_point in eps:
             if entry_point.name == backend:
@@ -183,7 +182,7 @@ class Triplestore:
                 pass
 
         raise ModuleNotFoundError(
-            "No tripper backend named '{backend}'",
+            f"No tripper backend named '{backend}'",
             name=backend,
         )
 

--- a/tripper/triplestore.py
+++ b/tripper/triplestore.py
@@ -169,7 +169,9 @@ class Triplestore:
             eps = entry_points().get("tripper.backends", ())
         else:
             # New entry_point interface from Python 3.10+
-            eps = entry_points(group="tripper.backends")
+            eps = entry_points(  # pylint: disable=unexpected-keyword-arg
+                group="tripper.backends"
+            )
         for entry_point in eps:
             if entry_point.name == backend:
                 return importlib.import_module(entry_point.module)


### PR DESCRIPTION
# Description:
- Updated entry point interface to not fail for Python 3.6 and 3.7
- Added test for custom plugin
- Made `__init__()` a required method in the backend interface definition

## Type of change:
<!-- Put an `x` in the box that applies. -->
- [x] Bug fix.
- [ ] New feature.
- [ ] Documentation update.

## Checklist for the reviewer:
<!-- Put an `x` in the boxes that apply. These can be filled by reviewer after the PR is created. -->

This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
