### PR TITLE
Clearified that tripper does not depend on DLite and Pydantic

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,7 @@
 """Test utils"""
 # pylint: disable=invalid-name,too-few-public-methods
-import dlite
+import warnings
+
 import pytest
 
 from tripper import DCTERMS, RDFS, XSD, Literal
@@ -18,16 +19,25 @@ from tripper.utils import (
 # Test infer_iri()
 assert infer_iri(RDFS.subClassOf) == RDFS.subClassOf
 
-coll = dlite.Collection()
-assert infer_iri(coll.meta) == coll.meta.uri
-assert infer_iri(coll) == coll.uuid
+
+# We have no dependencies on DLite, hence don't assume that it is installed.
+# In case we have dlite, lets see if we can infer IRIs
+try:
+    import dlite
+except ImportError:
+    warnings.warn("DLite-Python not installed, skipping infering DLite IRIs")
+else:
+    coll = dlite.Collection()
+    assert infer_iri(coll.meta) == coll.meta.uri
+    assert infer_iri(coll) == coll.uuid
+
 
 # We have no dependencies on pydantic, hence don't assume that it is installed.
 # But if it is, infer_iri() should be able to infer IRIs from SOFT7 datamodels.
 try:
     from pydantic import AnyUrl, BaseModel, Field
 except ImportError:
-    pass
+    warnings.warn("Pydantic not installed, skipping infering pydantic IRIs")
 else:
     from typing import Any, Optional
 

--- a/tripper/utils.py
+++ b/tripper/utils.py
@@ -39,6 +39,12 @@ class UnusedArgumentWarning(Warning):
 
 def infer_iri(obj):
     """Return IRI of the individual that stands for object `obj`."""
+
+    # Please note that tripper does not depend on neither DLite nor Pydantic.
+    # Hence neither of these packages are imported.  However, due to duck-
+    # typing, infer_iri() is still able to recognise DLite and Pydantic
+    # objects and infer their IRIs.
+
     if isinstance(obj, str):
         iri = obj
     elif hasattr(obj, "uri") and isinstance(obj.uri, str):


### PR DESCRIPTION
# Description:
Removed hard requirement on DLite in tests to clarify that tripper does not depend on DLite and Pydantic.


## Type of change:
<!-- Put an `x` in the box that applies. -->
- [ ] Bug fix.
- [ ] New feature.
- [ ] Documentation update.
- [ ] Testing.

## Checklist for the reviewer:
<!-- Put an `x` in the boxes that apply. These can be filled by reviewer after the PR is created. -->

This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
