### PR TITLE
Expand pint requirements to include more versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dynamic = ["version"]
 
 dependencies = [
     "typing-extensions ~=4.7; python_version<'3.8'",
-    "pint==0.16.1",
+    "pint>=0.16.1,<0.23",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dynamic = ["version"]
 
 dependencies = [
     "typing-extensions ~=4.7; python_version<'3.8'",
-    "pint ~=0.18",
+    "pint==0.16.1",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
# Description:
The tests on github work both with pint==0.16.1 and with the latest version.
I have therefore set up the whole range as acceptable for now. 
Thie is needed as tripper is being used by programs that use pint 0.16.1 (OntoFlow and the QuantumEspresso plugin for Aiida/ExecFlow)

## Type of change:
<!-- Put an `x` in the box that applies. -->
- [ ] Bug fix.
- [ ] New feature.
- [ ] Documentation update.
- [ ] Testing.

## Checklist for the reviewer:
<!-- Put an `x` in the boxes that apply. These can be filled by reviewer after the PR is created. -->

This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
