### PR TITLE
Added UnknownUnitError

### DIFF
--- a/tripper/mappings/mappings.py
+++ b/tripper/mappings/mappings.py
@@ -57,6 +57,10 @@ class MissingRelationError(MappingError):
     """There are missing relations in RDF triples."""
 
 
+class UnknownUnitError(MappingError):
+    """A unit does not exists in the pint unit registry."""
+
+
 class StepType(Enum):
     """Type of mapping step when going from the output to the inputs."""
 


### PR DESCRIPTION
# Description:
Added UnknownUnitError.

Motivation: Using a unit that is not in the Pint unit registry results in a completely ununderstandable error message. The idea is to issue understandable UnknownUnitError's whenever an unknown unit is used.

Currently this error is only imported by DLite, but the intention is to used in tripper as well.

## Type of change:
<!-- Put an `x` in the box that applies. -->
- [ ] Bug fix.
- [x] New feature.
- [ ] Documentation update.
- [ ] Testing.

## Checklist for the reviewer:
<!-- Put an `x` in the boxes that apply. These can be filled by reviewer after the PR is created. -->

This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
