### PR TITLE
Make it possible to expose an existing rdflib graph via tripper

### DIFF
--- a/tests/test_triplestore.py
+++ b/tests/test_triplestore.py
@@ -182,6 +182,7 @@ def test_backend_rdflib_graph(
 ) -> None:
     """Test rdflib backend, using the `graph` keyword argument to expose an
     existing rdflib graph with tripper."""
+    pytest.importorskip("rdflib")
     from rdflib import Graph, URIRef
 
     from tripper import RDF, RDFS, Triplestore

--- a/tests/test_triplestore.py
+++ b/tests/test_triplestore.py
@@ -177,6 +177,30 @@ def test_backend_rdflib_base_iri(
     ts.close()
 
 
+def test_backend_rdflib_graph(
+    get_ontology_path: "Callable[[str], Path]",
+) -> None:
+    """Test rdflib backend, using the `graph` keyword argument to expose an
+    existing rdflib graph with tripper."""
+    from rdflib import Graph, URIRef
+
+    from tripper import RDF, RDFS, Triplestore
+
+    graph = Graph()
+    graph.parse(source=get_ontology_path("family"))
+
+    # Test that triples from the original graph are available via tripper
+    ts = Triplestore(backend="rdflib", graph=graph)
+    FAM = ts.bind("fam", "http://onto-ns.com/ontologies/examples/family#")
+    assert ts.value(FAM.Father, RDFS.subClassOf) == FAM.Person
+    assert ts.value(FAM.Dauther, RDFS.subClassOf) == FAM.Person
+
+    # Test that triples added with tripper are available in the original
+    # graph
+    ts.add_triples([(":Nils", RDF.type, FAM.Father)])
+    assert graph.value(URIRef(":Nils"), URIRef(RDF.type)) == URIRef(FAM.Father)
+
+
 def test_backend_ontopy(get_ontology_path: "Callable[[str], Path]") -> None:
     """Specifically test the ontopy backend Triplestore.
 

--- a/tripper/backends/rdflib.py
+++ b/tripper/backends/rdflib.py
@@ -58,6 +58,8 @@ class RdflibStrategy:
             storage.  When `close()` is called, the storage will be
             overwritten with the current content of the triplestore.
         format: Format of storage specified with `base_iri`.
+        graph: A rdflib.Graph instance to expose with tripper, instead of
+            creating a new empth Graph object.
     """
 
     def __init__(
@@ -66,13 +68,14 @@ class RdflibStrategy:
         database: "Optional[str]" = None,
         triplestore_url: "Optional[str]" = None,
         format: "Optional[str]" = None,  # pylint: disable=redefined-builtin
+        graph: "Graph" = None,
     ) -> None:
         if base_iri:
             warnings.warn("base_iri", UnusedArgumentWarning, stacklevel=2)
         if database:
             warnings.warn("database", UnusedArgumentWarning, stacklevel=2)
 
-        self.graph = Graph()
+        self.graph = graph if graph else Graph()
         self.triplestore_url = triplestore_url
         if self.triplestore_url is not None:
             if format is None:

--- a/tripper/backends/rdflib.py
+++ b/tripper/backends/rdflib.py
@@ -60,7 +60,7 @@ class RdflibStrategy:
             overwritten with the current content of the triplestore.
         format: Format of storage specified with `base_iri`.
         graph: A rdflib.Graph instance to expose with tripper, instead of
-            creating a new empth Graph object.
+            creating a new empty Graph object.
     """
 
     def __init__(


### PR DESCRIPTION
# Description:
Added graph option to the rdflib backend that allows to expose an existing rdflib graph via tripper.

Use as follows:
```
graph = Graph()
graph.parse(...)
ts = Triplestore(backend="rdflib", graph=graph)  # all triples in the original graph are now exposed via tripper
```

## Type of change:
<!-- Put an `x` in the box that applies. -->
- [ ] Bug fix.
- [x] New feature.
- [ ] Documentation update.
- [ ] Testing.

## Checklist for the reviewer:
<!-- Put an `x` in the boxes that apply. These can be filled by reviewer after the PR is created. -->

This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
