### PR TITLE
Bump release workflow to python from 3.7 to 3.9

### DIFF
--- a/.github/workflows/cd_release.yml
+++ b/.github/workflows/cd_release.yml
@@ -20,13 +20,13 @@ jobs:
       # Build package
       python_package: true
       package_dirs: tripper
-      python_version_build: "3.7"
+      python_version_build: "3.9"
       build_cmd: "pip install -U flit && flit build"
       publish_on_pypi: true
 
       # Build & publish documentation
       update_docs: true
-      python_version_docs: "3.7"
+      python_version_docs: "3.9"
       doc_extras: "[docs]"
       changelog_exclude_labels: "skip_changelog,duplicate,question,invalid,wontfix"
     secrets:


### PR DESCRIPTION
# Description
Because documentation will no longer build on python 3.7, we bump its release job together with the package build from 3.7 to 3.9.

Closes #191.

## Type of change
- [x] Bug fix and code cleanup
- [ ] New feature
- [ ] Documentation update
- [ ] Testing


## Checklist for the reviewer
This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
- [ ] Is the code properly tested?
