### PR TITLE
Allow prefix with digits

### DIFF
--- a/tripper/triplestore.py
+++ b/tripper/triplestore.py
@@ -99,7 +99,7 @@ hasCost = DM.hasCost
 
 
 # Regular expression matching a prefixed IRI
-_MATCH_PREFIXED_IRI = re.compile(r"^([a-z]+):([^/]{1}.*)$")
+_MATCH_PREFIXED_IRI = re.compile(r"^([a-z][a-z0-9]*):([^/]{1}.*)$")
 
 
 class Triplestore:


### PR DESCRIPTION
# Description
Allow prefix with digits. For example `ss3:AbaqusSimpleMaterialCardTemplate`

## Type of change
- [x] Bug fix and code cleanup
- [ ] New feature
- [ ] Documentation update
- [ ] Testing


## Checklist for the reviewer
This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
- [ ] Is the code properly tested?
