### PR TITLE
In tripper.convert, commented out recognised keys for oteapi strategies

### DIFF
--- a/tripper/convert/convert.py
+++ b/tripper/convert/convert.py
@@ -36,13 +36,13 @@ BASIC_RECOGNISED_KEYS = {
     "label": RDFS.label,
     "comment": RDFS.comment,
     "mapsTo": MAP.mapsTo,
-    "dataresource": OTEIO.DataResourceStrategy,
-    "parse": OTEIO.ParseStrategy,  # add to ontology
-    "generate": OTEIO.GenerateStrategy,  # add to ontology
-    "mapping": OTEIO.MappingStrategy,
-    "function": OTEIO.FunctionStrategy,
-    "transformation": OTEIO.TransformationStrategy,
-    "configuration": OTEIO.Configuration,
+    # "dataresource": OTEIO.DataResourceStrategy,
+    # "parse": OTEIO.ParseStrategy,  # add to ontology
+    # "generate": OTEIO.GenerateStrategy,  # add to ontology
+    # "mapping": OTEIO.MappingStrategy,
+    # "function": OTEIO.FunctionStrategy,
+    # "transformation": OTEIO.TransformationStrategy,
+    # "configuration": OTEIO.Configuration,
 }
 
 


### PR DESCRIPTION
# Description
For some reason uncommenting these recognised keys makes load_container() returning a string with the IRI for the blank node representing the configuration of a strategy, instead of a Python dict with the configuration.

Needs more debugging, or preferable, an improved way for OTEAPI to serialise strategy configurations to RDF.

## Type of change
- [x] Bug fix and code cleanup
- [ ] New feature
- [ ] Documentation update
- [ ] Testing


## Checklist for the reviewer
This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
- [ ] Is the code properly tested?
