### PR TITLE
Do not save cache while interpreter shotdown.

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -57,10 +57,11 @@ The `check=True` enables checking for existing IRIs.
 'https://w3id.org/emmo#EMMO_eb77076b_a104_42ac_a065_798b2d2809ad'
 
 # This fails because we set `check=True`
->>> EMMO.invalid_name
+>>> EMMO.invalid_name  # doctest: +ELLIPSIS
 Traceback (most recent call last):
     ...
 tripper.errors.NoSuchIRIError: https://w3id.org/emmo#invalid_name
+Maybe you have to remove the cache file: ...
 
 ```
 

--- a/tripper/namespace.py
+++ b/tripper/namespace.py
@@ -163,7 +163,7 @@ class Namespace:
         """Save current cache."""
         # pylint: disable=invalid-name
         cachefile = self._get_cachefile()
-        if self._iris:
+        if self._iris and not sys.is_finalizing():
             with open(cachefile, "wb") as f:
                 pickle.dump(self._iris, f)
 
@@ -186,7 +186,11 @@ class Namespace:
         if self._iris and name in self._iris:
             return self._iris[name]
         if self._check:
-            raise NoSuchIRIError(self._iri + name)
+            msg = ""
+            cachefile = self._get_cachefile()
+            if cachefile.exists():
+                msg = f"\nMaybe you have to remove the cache file: {cachefile}"
+            raise NoSuchIRIError(self._iri + name + msg)
         return self._iri + name
 
     def __getitem__(self, key):


### PR DESCRIPTION
# Description
This avoids strange sporadic failures when the interpreter is shutting, since the open() function may no longer exists when the Namespace.__del__() method is called.

The drawback of this fix is that you explicitely have to case the cache before exiting the interpreter.

## Type of change
- [x] Bug fix and code cleanup
- [ ] New feature
- [ ] Documentation update
- [ ] Testing


## Checklist for the reviewer
This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
- [ ] Is the code properly tested?
