### PR TITLE
Get restrictions as dicts

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -240,8 +240,8 @@ With the `return_dicts` argument set to false, you will instead get an iterator 
 
 ```python
 >>> g = ts.restrictions(cls=ONTO.Bacteria, property=EMMO.hasPart, return_dicts=False)
->>> list(g)  # doctest: +ELLIPSIS
-['_:...']
+>>> next(g) == iri
+True
 
 ```
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -229,7 +229,7 @@ It returns an iterator over all restrictions that matches the provided criteria.
 For example:
 
 ```python
->>> g = ts.restrictions(cls=ONTO.Bacteria, property=EMMO.hasPart, return_dicts=True)
+>>> g = ts.restrictions(cls=ONTO.Bacteria, property=EMMO.hasPart, asdict=True)
 >>> list(g)  # doctest: +ELLIPSIS
 [{'iri': '_:...', 'cls': 'http://example.com/onto#Bacteria', 'property': 'https://w3id.org/emmo#EMMO_17e27c22_37e1_468c_9dd7_95e137f73e7f', 'type': 'exactly', 'cardinality': 1, 'value': 'http://example.com/onto#Cell'}]
 
@@ -238,7 +238,7 @@ For example:
 With the `return_dicts` argument set to false, an iterator over the IRIs of all matching restrictions is returned:
 
 ```python
->>> g = ts.restrictions(cls=ONTO.Bacteria, property=EMMO.hasPart, return_dicts=False)
+>>> g = ts.restrictions(cls=ONTO.Bacteria, property=EMMO.hasPart, asdict=False)
 >>> next(g) == iri
 True
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -187,13 +187,12 @@ True
 ```
 
 ### Class restrictions
-When working with OWL ontologies, you often need to look up or add class restrictions.
-A [restriction] restricts a class to only those individuals that satisfy the restriction.
-The Triplestore class has two convenient methods for this, that don't require knowledge about how restrictions are represented in RDF.
-They only support basic restrictions without any nested logical constructs.
+When working with OWL ontologies, it is often required to inspect or add class [restriction]s.
+The Triplestore class has two convenient methods for this, that do not require knowledge about how restrictions are represented in RDF.
+Only support basic restrictions, without any nested logical constructs, are supoprted.
 For more advanced restrictions, we recommend to use [EMMOntoPy] or [Owlready2].
 
-A restriction is described by the following set of parameters.
+A [restriction] is described by the following set of parameters.
 
   * **cls**: IRI of class to which the restriction applies.
   * **property**: IRI of restriction property.
@@ -208,9 +207,9 @@ A restriction is described by the following set of parameters.
   * **cardinality**: the cardinality value for cardinality restrictions.
   * **value**: The IRI or literal value of the restriction target.
 
-For example. Lets assume that you have a class `onto:Bacteria` that you want to logically restrict to be unicellular.
+As an example, the class `onto:Bacteria` can be logically restricted to be unicellular.
 In Manchester syntax, this can be stated as `onto:Bacteria emmo:hasPart exactly 1 onto:Cell`.
-With tripper, you can state it with
+With Tripper this can be stated as:
 
 ```python
 >>> iri = ts.add_restriction(
@@ -225,7 +224,7 @@ With tripper, you can state it with
 The returned `iri` is the blank node IRI of the new restriction.
 
 
-To find the above restriction, you can use the `restrictions()` method.
+To find the above restriction, the `restrictions()` method can be used.
 It returns an iterator over all restrictions that matches the provided criteria.
 For example:
 
@@ -236,7 +235,7 @@ For example:
 
 ```
 
-With the `return_dicts` argument set to false, you will instead get an iterator over the IRIs of all matching restrictions:
+With the `return_dicts` argument set to false, an iterator over the IRIs of all matching restrictions is returned:
 
 ```python
 >>> g = ts.restrictions(cls=ONTO.Bacteria, property=EMMO.hasPart, return_dicts=False)

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -186,6 +186,66 @@ True
 
 ```
 
+### Class restrictions
+When working with OWL ontologies, you often need to look up or add class restrictions.
+A [restriction] restricts a class to only those individuals that satisfy the restriction.
+The Triplestore class has two convenient methods for this, that don't require knowledge about how restrictions are represented in RDF.
+They only support basic restrictions without any nested logical constructs.
+For more advanced restrictions, we recommend to use [EMMOntoPy] or [Owlready2].
+
+A restriction is described by the following set of parameters.
+
+  * **cls**: IRI of class to which the restriction applies.
+  * **property**: IRI of restriction property.
+  * **type**: The type of the restriction.  Should be one of:
+    - *some*: existential restriction (target is a class IRI)
+    - *only*: universal restriction (target is a class IRI)
+    - *exactly*: cardinality restriction (target is a class IRI)
+    - *min*: minimum cardinality restriction (target is a class IRI)
+    - *max*: maximum cardinality restriction (target is a class IRI)
+    - *value*: Value restriction (target is an IRI of an individual or a literal)
+
+  * **cardinality**: the cardinality value for cardinality restrictions.
+  * **value**: The IRI or literal value of the restriction target.
+
+For example. Lets assume that you have a class `onto:Bacteria` that you want to logically restrict to be unicellular.
+In Manchester syntax, this can be stated as `onto:Bacteria emmo:hasPart exactly 1 onto:Cell`.
+With tripper, you can state it with
+
+```python
+>>> iri = ts.add_restriction(
+...     cls=ONTO.Bacteria,
+...     property=EMMO.hasPart,
+...     type="exactly",
+...     cardinality=1,
+...     value=ONTO.Cell,
+... )
+
+```
+The returned `iri` is the blank node IRI of the new restriction.
+
+
+To find the above restriction, you can use the `restrictions()` method.
+It returns an iterator over all restrictions that matches the provided criteria.
+For example:
+
+```python
+>>> g = ts.restrictions(cls=ONTO.Bacteria, property=EMMO.hasPart, return_dicts=True)
+>>> list(g)  # doctest: +ELLIPSIS
+[{'iri': '_:...', 'cls': 'http://example.com/onto#Bacteria', 'property': 'https://w3id.org/emmo#EMMO_17e27c22_37e1_468c_9dd7_95e137f73e7f', 'type': 'exactly', 'cardinality': 1, 'value': 'http://example.com/onto#Cell'}]
+
+```
+
+With the `return_dicts` argument set to false, you will instead get an iterator over the IRIs of all matching restrictions:
+
+```python
+>>> g = ts.restrictions(cls=ONTO.Bacteria, property=EMMO.hasPart, return_dicts=False)
+>>> list(g)  # doctest: +ELLIPSIS
+['_:...']
+
+```
+
+
 ### Utilities
 *Todo: Describe the `tripper.utils` module*
 
@@ -272,3 +332,6 @@ https://emmc-asbl.github.io/tripper/latest/api_reference/literal/#tripper.litera
 [EMMO]: https://emmc.eu/emmo/
 [Function Ontology (FnO)]: https://fno.io/
 [list of currently supported backends]: https://github.com/EMMC-ASBL/tripper?tab=readme-ov-file#available-backends
+[EMMOntoPy]: https://emmo-repo.github.io/EMMOntoPy/
+[Owlready2]: https://pypi.org/project/owlready2/
+[restriction]: https://www.w3.org/TR/owl-ref/#Restriction

--- a/tests/test_triplestore.py
+++ b/tests/test_triplestore.py
@@ -210,7 +210,7 @@ def test_restriction() -> None:  # pylint: disable=too-many-statements
                 "property": "http://example.com/onto#hasBodyPart",
                 "type": "exactly",
                 "value": "http://example.com/onto#Head",
-                "cardinality": Literal("3", datatype=XSD.nonNegativeInteger),
+                "cardinality": 3,
             },
             {
                 "cls": "http://example.com/onto#Kerberos",

--- a/tests/test_triplestore.py
+++ b/tests/test_triplestore.py
@@ -167,22 +167,34 @@ def test_restriction() -> None:  # pylint: disable=too-many-statements
         )
 
     # Test find restriction
-    assert set(ts.restrictions()) == {iri, iri2, iri3}
-    assert set(ts.restrictions(cls=EX.Kerberos)) == {iri2, iri3}
-    assert set(ts.restrictions(cls=EX.Animal)) == {iri}
-    assert not set(ts.restrictions(cls=EX.Dog))
-    assert set(ts.restrictions(cls=EX.Kerberos, cardinality=3)) == {iri2}
-    assert set(ts.restrictions(cardinality=3)) == {iri2}
-    assert not set(ts.restrictions(cls=EX.Kerberos, cardinality=2))
-    assert set(ts.restrictions(property=EX.hasBodyPart)) == {iri2}
-    assert set(ts.restrictions(property=EX.hasPart)) == {iri}
-    assert not set(ts.restrictions(property=EX.hasNoPart))
-    assert set(ts.restrictions(value=EX.Cell)) == {iri}
-    assert set(ts.restrictions(value=EX.Head)) == {iri2}
-    assert not set(ts.restrictions(value=EX.Leg))
-    assert set(ts.restrictions(value=EX.Cell, type="some")) == {iri}
-    assert set(ts.restrictions(value=EX.Head, type="exactly")) == {iri2}
-    assert set(ts.restrictions(value=Literal("The port of Hades"))) == {iri3}
+    assert set(ts.restrictions(asdict=False)) == {iri, iri2, iri3}
+    assert set(ts.restrictions(cls=EX.Kerberos, asdict=False)) == {iri2, iri3}
+    assert set(ts.restrictions(cls=EX.Animal, asdict=False)) == {iri}
+    assert not set(ts.restrictions(cls=EX.Dog, asdict=False))
+    assert set(
+        ts.restrictions(cls=EX.Kerberos, cardinality=3, asdict=False)
+    ) == {iri2}
+    assert set(ts.restrictions(cardinality=3, asdict=False)) == {iri2}
+    assert not set(
+        ts.restrictions(cls=EX.Kerberos, cardinality=2, asdict=False)
+    )
+    assert set(ts.restrictions(property=EX.hasBodyPart, asdict=False)) == {
+        iri2
+    }
+    assert set(ts.restrictions(property=EX.hasPart, asdict=False)) == {iri}
+    assert not set(ts.restrictions(property=EX.hasNoPart, asdict=False))
+    assert set(ts.restrictions(value=EX.Cell, asdict=False)) == {iri}
+    assert set(ts.restrictions(value=EX.Head, asdict=False)) == {iri2}
+    assert not set(ts.restrictions(value=EX.Leg, asdict=False))
+    assert set(ts.restrictions(value=EX.Cell, type="some", asdict=False)) == {
+        iri
+    }
+    assert set(
+        ts.restrictions(value=EX.Head, type="exactly", asdict=False)
+    ) == {iri2}
+    assert set(
+        ts.restrictions(value=Literal("The port of Hades"), asdict=False)
+    ) == {iri3}
 
     with pytest.raises(ArgumentValueError):
         set(ts.restrictions(value=EX.Cell, type="wrong_type"))
@@ -190,10 +202,8 @@ def test_restriction() -> None:  # pylint: disable=too-many-statements
     with pytest.raises(ArgumentValueError):
         set(ts.restrictions(type="value", cardinality=2))
 
-    # Test return_dicts
-    dicts = sorted(
-        ts.restrictions(return_dicts=True), key=lambda d: d["value"]
-    )
+    # Test returning as dicts (asdict=True)
+    dicts = sorted(ts.restrictions(asdict=True), key=lambda d: d["value"])
     for d in dicts:  # Remove iri keys, since they refer to blank nodes
         d.pop("iri")
     assert dicts == sorted(
@@ -223,7 +233,7 @@ def test_restriction() -> None:  # pylint: disable=too-many-statements
         key=lambda d: d["value"],
     )
 
-    dicts = list(ts.restrictions(type="some", return_dicts=True))
+    dicts = list(ts.restrictions(type="some", asdict=True))
     for d in dicts:  # Remove iri keys, since they refer to blank nodes
         d.pop("iri")
     assert dicts == [

--- a/tripper/triplestore.py
+++ b/tripper/triplestore.py
@@ -721,8 +721,6 @@ class Triplestore:
         "value": (OWL.hasValue, None),
     }
 
-    # xtype: "TypeLiteral['some', 'only', 'exactly', 'min', 'max', 'value']",
-
     def add_restriction(  # pylint: disable=redefined-builtin
         self,
         cls: str,
@@ -785,11 +783,6 @@ class Triplestore:
 
         self.add_triples(triples)
         return iri
-
-        # xtype: (
-        #     "Optional[TypeLiteral['some', 'only', 'exactly', 'min', "
-        #     "'max', 'value']]"
-        # ) = None,
 
     def restrictions(  # pylint: disable=redefined-builtin
         self,
@@ -878,8 +871,8 @@ class Triplestore:
         - cls: (str) IRI of class to which the restriction applies.
         - property: (str) IRI of restriction property
         - type: (str) One of: "some", "only", "exactly", "min", "max", "value".
-        - value: (str|Literal) IRI or literal value of the restriction target.
         - cardinality: (int) Restriction cardinality (optional).
+        - value: (str|Literal) IRI or literal value of the restriction target.
         """
         dct = dict(self.predicate_objects(iri))
         if OWL.onClass in dct:
@@ -899,8 +892,8 @@ class Triplestore:
             "cls": self.value(predicate=RDFS.subClassOf, object=iri),
             "property": dct[OWL.onProperty],
             "type": t,
+            "cardinality": int(dct[c]) if c else None,
             "value": dct[p],
-            "cardinality": dct.get(c, None),
         }
 
     def map(

--- a/tripper/triplestore.py
+++ b/tripper/triplestore.py
@@ -799,7 +799,7 @@ class Triplestore:
         value: "Optional[Union[str, Literal]]" = None,
         type: "Optional[RestrictionType]" = None,
         cardinality: "Optional[int]" = None,
-        return_dicts: bool = False,
+        asdict: bool = True,
     ) -> "Generator[Triple, None, None]":
         # pylint: disable=too-many-boolean-expressions
         """Returns a generator over matching restrictions.
@@ -818,13 +818,13 @@ class Triplestore:
                   or a literal)
 
             cardinality: the cardinality value for cardinality restrictions.
-            return_dicts: Whether to returned generator is over dicts (see
+            asdict: Whether to returned generator is over dicts (see
                 _get_restriction_dict()). Default is to return a generator
                 over blank node IRIs.
 
         Returns:
-            A generator over matching restrictions.  See `return_dicts`
-            argument for types iterated over.
+            A generator over matching restrictions.  See `asdict` argument
+            for types iterated over.
         """
         if type is None:
             types = set(self._restriction_types.keys())
@@ -869,7 +869,7 @@ class Triplestore:
                     or any(self.has(iri, c, lcard) for c in card)
                 )
             ):
-                yield self._get_restriction_dict(iri) if return_dicts else iri
+                yield self._get_restriction_dict(iri) if asdict else iri
 
     def _get_restriction_dict(self, iri):
         """Return a dict describing restriction with `iri`.


### PR DESCRIPTION
# Description
Added a `return_dicts` keyword argument to the `Triplestore.retrictions()` method, to allow to get the restrictions as dicts instead of blank nodes. 

Other changes:
* Also renamed the `target` argument of `Triplestore.add_retriction()` and `Triplestore.retrictions()` to `value` in order to be consistent with the naming in EMMOntoPy. These two methods are a very new addition to tripper that haven't been used yet. This change that this change will break existing code is therefore very small.
* Added tests.
* Added documentation in the tutorial.

**Question**
Should we change the default of `return_dicts` to be true? If so, this is the right time to do it, before people starts to use these methods.

## Type of change
- [x] Bug fix and code cleanup
- [x] New feature
- [x] Documentation update
- [x] Testing


## Checklist for the reviewer
This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
- [ ] Is the code properly tested?
