### PR TITLE
Get rid of the last warning in the tests

### DIFF
--- a/tests/test_literals.py
+++ b/tests/test_literals.py
@@ -5,6 +5,8 @@
 
 def test_untyped() -> None:
     """Test creating a untyped literal."""
+    import pytest
+
     from tripper.literal import RDF, XSD, Literal
 
     literal = Literal("Hello world!")
@@ -19,8 +21,10 @@ def test_untyped() -> None:
     assert literal == Literal("Hello world!", datatype=XSD.string)
     assert literal == Literal("Hello world!", datatype=XSD.token)
     assert literal == Literal("Hello world!", datatype=RDF.JSON)
-    assert literal != Literal("Hello world!", datatype=XSD.ENTITY)
     assert literal == Literal("Hello world!", lang="en")
+
+    with pytest.warns(UserWarning, match="^unknown datatype"):
+        assert literal != Literal("Hello world!", datatype=XSD.ENTITY)
 
 
 def test_string() -> None:


### PR DESCRIPTION
# Description
Get rid of the last warning when running the tests.

## Type of change
- [ ] Bug fix and code cleanup
- [ ] New feature
- [ ] Documentation update
- [x] Testing


## Checklist for the reviewer
This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
- [ ] Is the code properly tested?
