### PR TITLE
Added a fix for parsing rdflib literals.

### DIFF
--- a/tests/test_literals.py
+++ b/tests/test_literals.py
@@ -256,6 +256,33 @@ def test_parse_literal() -> None:
     assert literal.datatype == "http://example.com/vocab#mytype"
 
 
+def test_rdflib_literal():
+    """Test parsing rdflib literals."""
+    import pytest
+
+    rdflib = pytest.importorskip("rdflib")
+    from tripper import RDF, XSD
+    from tripper.utils import parse_literal
+
+    rdflib_literal = rdflib.Literal(1, datatype=rdflib.XSD.integer)
+    literal = parse_literal(rdflib_literal)
+    assert literal.value == 1
+    assert literal.lang is None
+    assert literal.datatype == XSD.integer
+
+    rdflib_literal = rdflib.Literal("abc", datatype=rdflib.XSD.string)
+    literal = parse_literal(rdflib_literal)
+    assert literal.value == "abc"
+    assert literal.lang is None
+    assert literal.datatype == XSD.string
+
+    rdflib_literal = rdflib.Literal('["a", 1, 2]', datatype=rdflib.RDF.JSON)
+    literal = parse_literal(rdflib_literal)
+    assert literal.value == '["a", 1, 2]'
+    assert literal.lang is None
+    assert literal.datatype == RDF.JSON
+
+
 def test_equality() -> None:
     """Test equality."""
     from tripper import RDF, XSD, Literal

--- a/tests/test_literals.py
+++ b/tests/test_literals.py
@@ -244,6 +244,11 @@ def test_parse_literal() -> None:
     assert literal.lang is None
     assert literal.datatype == RDF.HTML
 
+    literal = parse_literal(f'"""["a", 1, 2]"""^^<{RDF.JSON}>')
+    assert literal.value == '["a", 1, 2]'
+    assert literal.lang is None
+    assert literal.datatype == RDF.JSON
+
     with pytest.warns(UserWarning, match="unknown datatype"):
         literal = parse_literal('"value"^^http://example.com/vocab#mytype')
     assert literal.value == "value"

--- a/tripper/utils.py
+++ b/tripper/utils.py
@@ -237,7 +237,7 @@ def parse_literal(literal: "Any") -> "Any":
     # This should handle rdflib literals correctly (and probably most other
     # literal representations as well)
     if hasattr(literal, "value"):
-        # Note that in rdflib 6.3, the `value` attribute may None for some
+        # Note that in rdflib 6.3, the `value` attribute may be None for some
         # datatypes (like rdf:JSON) even though a non-empty value exists.
         # As a workaround, we use the string representation if the value
         # attribute is None.

--- a/tripper/utils.py
+++ b/tripper/utils.py
@@ -234,10 +234,9 @@ def parse_literal(literal: "Any") -> "Any":
     ):
         datatype = str(literal.datatype)
 
-    # This will handle rdflib literals correctly and probably most other
-    # literal representations as well.
-    if hasattr(literal, "value"):
-        return Literal(literal.value, lang=lang, datatype=datatype)
+    # This will handle rdflib literals correctly.
+    if hasattr(literal, "n3"):
+        return Literal(str(literal), lang=lang, datatype=datatype)
 
     if not isinstance(literal, str):
         if isinstance(literal, tuple(Literal.datatypes)):

--- a/tripper/utils.py
+++ b/tripper/utils.py
@@ -234,8 +234,15 @@ def parse_literal(literal: "Any") -> "Any":
     ):
         datatype = str(literal.datatype)
 
-    # This will handle rdflib literals correctly.
-    if hasattr(literal, "n3"):
+    # This should handle rdflib literals correctly (and probably most other
+    # literal representations as well)
+    if hasattr(literal, "value"):
+        # Note that in rdflib 6.3, the `value` attribute may None for some
+        # datatypes (like rdf:JSON) even though a non-empty value exists.
+        # As a workaround, we use the string representation if the value
+        # attribute is None.
+        if literal.value is not None:
+            return Literal(literal.value, lang=lang, datatype=datatype)
         return Literal(str(literal), lang=lang, datatype=datatype)
 
     if not isinstance(literal, str):


### PR DESCRIPTION
# Description
We cannot use the `value` attribute of an `rdflib.Literal` to access its value, since it is `None` for some datatypes (at least for rdf:JSON). 
Seems more robust to use the existence of the `n3()` method to test for a literal and the string representation to access its value.

## Type of change
- [x] Bug fix and code cleanup
- [ ] New feature
- [ ] Documentation update
- [ ] Testing


## Checklist for the reviewer
This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
- [ ] Is the code properly tested?
