### PR TITLE
Avoid that tripper.Namespace crashes if the cache directory cannot be accessed

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,6 +44,7 @@ repos:
     rev: 24.8.0
     hooks:
     - id: black
+      line-length: 79
 
   - repo: https://github.com/PyCQA/bandit
     rev: 1.7.9

--- a/README.md
+++ b/README.md
@@ -9,6 +9,13 @@ Tripper
 [![DOI](https://zenodo.org/badge/547162834.svg)](https://zenodo.org/badge/latestdoi/547162834)
 
 
+Getting started
+---------------
+* [Tutorial]
+* [Discovery of custom backends]
+* [Reference manual]
+* [Known issues]
+
 
 Basic concepts
 --------------
@@ -37,13 +44,6 @@ Advanced features
 The submodules `mappings` and `convert` provide additional functionality beyond interfacing triplestore backends:
 - **tripper.mappings**: traverse mappings stored in the triplestore and find possible mapping routes.
 - **tripper.convert**: convert between RDF and other data representations.
-
-
-Documentation
--------------
-* Getting started: See the [tutorial](docs/tutorial.md)
-* [Discovery of custom backends](docs/backend_discovery.md)
-* [Reference manual]
 
 
 Available backends
@@ -104,11 +104,14 @@ We gratefully acknowledge the following projects for supporting the development 
 
 
 
+[Tutorial]: docs/tutorial.md
+[Discovery of custom backends]: docs/backend_discovery.md
+[Reference manual]: https://emmc-asbl.github.io/tripper/latest/api_reference/triplestore/
+[Known issues]: https://emmc-asbl.github.io/tripper/latest/known-issues.md
 [tripper]: https://emmc-asbl.github.io/tripper
 [rdflib]: https://rdflib.readthedocs.io/en/stable/
 [PyPI]: https://pypi.org/project/tripper
 [PyBackTrip]: https://github.com/EMMC-ASBL/PyBackTrip/
-[Reference manual]: https://emmc-asbl.github.io/tripper/latest/api_reference/triplestore/
 [Literal]: https://emmc-asbl.github.io/tripper/latest/api_reference/triplestore/#tripper.triplestore.Literal
 [Namespace]: https://emmc-asbl.github.io/tripper/latest/api_reference/triplestore/#tripper.triplestore.Namespace
 [Triplestore]: https://emmc-asbl.github.io/tripper/latest/api_reference/triplestore/#tripper.triplestore.Triplestore

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,6 +9,13 @@ Tripper
 [![DOI](https://zenodo.org/badge/547162834.svg)](https://zenodo.org/badge/latestdoi/547162834)
 
 
+Getting started
+---------------
+* [Tutorial]
+* [Discovery of custom backends]
+* [Reference manual]
+* [Known issues]
+
 
 Basic concepts
 --------------
@@ -37,13 +44,6 @@ Advanced features
 The submodules `mappings` and `convert` provide additional functionality beyond interfacing triplestore backends:
 - **tripper.mappings**: traverse mappings stored in the triplestore and find possible mapping routes.
 - **tripper.convert**: convert between RDF and other data representations.
-
-
-Documentation
--------------
-* Getting started: See the [tutorial](tutorial.md)
-* [Discovery of custom backends](backend_discovery.md)
-* [Reference manual]
 
 
 Available backends
@@ -104,11 +104,14 @@ We gratefully acknowledge the following projects for supporting the development 
 
 
 
+[Tutorial]: tutorial.md
+[Discovery of custom backends]: backend_discovery.md
+[Reference manual]: https://emmc-asbl.github.io/tripper/latest/api_reference/triplestore/
+[Known issues]: https://emmc-asbl.github.io/tripper/latest/known-issues.md
 [tripper]: https://emmc-asbl.github.io/tripper
 [rdflib]: https://rdflib.readthedocs.io/en/stable/
 [PyPI]: https://pypi.org/project/tripper
 [PyBackTrip]: https://github.com/EMMC-ASBL/PyBackTrip/
-[Reference manual]: https://emmc-asbl.github.io/tripper/latest/api_reference/triplestore/
 [Literal]: https://emmc-asbl.github.io/tripper/latest/api_reference/triplestore/#tripper.triplestore.Literal
 [Namespace]: https://emmc-asbl.github.io/tripper/latest/api_reference/triplestore/#tripper.triplestore.Namespace
 [Triplestore]: https://emmc-asbl.github.io/tripper/latest/api_reference/triplestore/#tripper.triplestore.Triplestore

--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -1,0 +1,10 @@
+Known issues
+============
+
+* If you use the rdflib backend and don't have write permissions to
+  the cache directory (which e.g. can happen if you run Python in
+  docker as a non-root user), you may get a `urllib.error.HTTPError`
+  error when accessing an online rdf resource.
+
+  Setting the environment variable `XDG_CACHE_HOME` to a directory
+  that you have write access to will solve the problem.

--- a/tripper/backends/rdflib.py
+++ b/tripper/backends/rdflib.py
@@ -2,6 +2,12 @@
 
 For developers: The usage of `s`, `p`, and `o` represent the different parts of
 an RDF Triple: subject, predicate, and object.
+
+There is a issue with rdflib raising an `urllib.error.HTTPError`
+exception if you don't have write permissions to the cache directory.
+See [Known issues](https://emmc-asbl.github.io/tripper/latest/known-issues.md)
+for more details.
+
 """
 
 # pylint: disable=line-too-long

--- a/tripper/namespace.py
+++ b/tripper/namespace.py
@@ -152,7 +152,7 @@ class Namespace:
             if s.startswith(iri)
         )
 
-    def _get_cachefile(self) -> "Path":
+    def _get_cachefile(self) -> Path:
         """Return path to cache file for this namespace."""
         # pylint: disable=too-many-function-args
         name = self._iri.rstrip("#/").rsplit("/", 1)[-1]
@@ -162,10 +162,13 @@ class Namespace:
     def _save_cache(self):
         """Save current cache."""
         # pylint: disable=invalid-name
-        cachefile = self._get_cachefile()
-        if self._iris and not sys.is_finalizing():
-            with open(cachefile, "wb") as f:
-                pickle.dump(self._iris, f)
+        try:
+            cachefile = self._get_cachefile()
+            if self._iris and not sys.is_finalizing():
+                with open(cachefile, "wb") as f:
+                    pickle.dump(self._iris, f)
+        except OSError as exc:
+            warnings.warn(f"Cannot access cache file: {exc}")
 
     def _load_cache(self) -> bool:
         """Update cache with cache file.
@@ -173,23 +176,33 @@ class Namespace:
         Returns true if there exists a cache file to load from.
         """
         # pylint: disable=invalid-name
-        cachefile = self._get_cachefile()
-        if self._iris is None:
-            self._iris = {}
-        if cachefile.exists():
-            with open(cachefile, "rb") as f:
-                self._iris.update(pickle.load(f))  # nosec
-            return True
-        return False
+        try:
+            cachefile = self._get_cachefile()
+            if self._iris is None:
+                self._iris = {}
+            if cachefile.exists():
+                with open(cachefile, "rb") as f:
+                    self._iris.update(pickle.load(f))  # nosec
+                return True
+            return False
+        except OSError as exc:
+            warnings.warn(f"Cannot create cache directory: {exc}")
+            return False
 
     def __getattr__(self, name):
         if self._iris and name in self._iris:
             return self._iris[name]
         if self._check:
             msg = ""
-            cachefile = self._get_cachefile()
-            if cachefile.exists():
-                msg = f"\nMaybe you have to remove the cache file: {cachefile}"
+            try:
+                cachefile = self._get_cachefile()
+                if cachefile.exists():
+                    msg = (
+                        "\nMaybe you have to remove the cache file: "
+                        f"{cachefile}"
+                    )
+            except OSError as exc:
+                warnings.warn(f"Cannot access cache file: {exc}")
             raise NoSuchIRIError(self._iri + name + msg)
         return self._iri + name
 

--- a/tripper/namespace.py
+++ b/tripper/namespace.py
@@ -168,7 +168,11 @@ class Namespace:
                 with open(cachefile, "wb") as f:
                     pickle.dump(self._iris, f)
         except OSError as exc:
-            warnings.warn(f"Cannot access cache file: {exc}")
+            warnings.warn(
+                f"Cannot access cache file: {exc}\n\n"
+                "You can select cache directory with the XDG_CACHE_HOME "
+                "environment variable."
+            )
 
     def _load_cache(self) -> bool:
         """Update cache with cache file.
@@ -186,7 +190,11 @@ class Namespace:
                 return True
             return False
         except OSError as exc:
-            warnings.warn(f"Cannot create cache directory: {exc}")
+            warnings.warn(
+                f"Cannot create cache directory: {exc}\n\n"
+                "You can select cache directory with the XDG_CACHE_HOME "
+                "environment variable."
+            )
             return False
 
     def __getattr__(self, name):
@@ -202,7 +210,11 @@ class Namespace:
                         f"{cachefile}"
                     )
             except OSError as exc:
-                warnings.warn(f"Cannot access cache file: {exc}")
+                warnings.warn(
+                    f"Cannot access cache file: {exc}\n\n"
+                    "You can select cache directory with the XDG_CACHE_HOME "
+                    "environment variable."
+                )
             raise NoSuchIRIError(self._iri + name + msg)
         return self._iri + name
 


### PR DESCRIPTION
# Description
Avoid that tripper.Namespace crashes if the cache directory cannot be accessed.

Unfortunately, if you use tripper with the rdflib backend, you may still get errors if the cache dir is not accessible. Try e.g. 

    XDG_CACHE_HOME=/root/.cache pytest tests/test_namespace.py

as a non-root user. It will result in a `HTTPError`, which is caused by that rdflib doesn't have permissions to store a downloaded turtle file in the cache directory. 

## Type of change
- [x] Bug fix and code cleanup
- [ ] New feature
- [ ] Documentation update
- [ ] Testing


## Checklist for the reviewer
This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
- [ ] Is the code properly tested?
