### PR TITLE
Added option to Triplestore.value() to return a generator over all matching values

### DIFF
--- a/tests/test_triplestore.py
+++ b/tests/test_triplestore.py
@@ -496,3 +496,36 @@ def test_bind_errors():
         ts2.bind("ex")
     with pytest.raises(TypeError):
         ts2.bind("ex", Ellipsis)
+
+
+if True:
+    # def test_value():
+    #    """Test Triplestore.value()."""
+    pytest.importorskip("rdflib")
+
+    from tripper import DCTERMS, RDF, RDFS, Literal, Triplestore
+
+    ts = Triplestore(backend="rdflib")
+    EX = ts.bind("ex", "http://example.com#")
+    ts.add_triples(
+        [
+            (EX.mydata, RDF.type, EX.Dataset),
+            (EX.mydata, DCTERMS.title, Literal("My little data")),
+            (EX.mydata, RDFS.comment, Literal("First comment...")),
+            (EX.mydata, RDFS.comment, Literal("Second comment...", lang="en")),
+            (
+                EX.mydata,
+                RDFS.comment,
+                Literal("Anden kommentar...", lang="da"),
+            ),
+        ]
+    )
+    assert ts.value(subject=EX.mydata, predicate=RDF.type) == EX.Dataset
+    assert ts.value(subject=EX.mydata, predicate=DCTERMS.title) == Literal(
+        "My little data"
+    )
+    assert ts.value(
+        subject=EX.mydata, predicate=DCTERMS.title, lang="en"
+    ) == Literal("My little data")
+    # assert ts.value(subject=EX.mydata, predicate=RDF.type) == EX.Dataset
+    # assert ts.value(subject=EX.mydata, predicate=RDF.type) == EX.Dataset

--- a/tripper/triplestore.py
+++ b/tripper/triplestore.py
@@ -581,10 +581,10 @@ class Triplestore:
             object: Possible criteria to match.
             default: Value to return if no matches are found.
             any: Used to define how many values to return. Can be set to:
-                'False' (default): return the value or raise UniquenessError
+                `False` (default): return the value or raise UniquenessError
                 if there is more than one matching value.
-                 'True': return any matching value if there is more than one.
-                 'None': return a generator over all matching values.
+                `True`: return any matching value if there is more than one.
+                `None`: return a generator over all matching values.
             lang: If provided, require that the value must be a localised
                 literal with the given language code.
 
@@ -625,7 +625,7 @@ class Triplestore:
         except StopIteration:
             return value
 
-        if any:
+        if any is True:
             return value
         raise UniquenessError("More than one match")
 

--- a/tripper/triplestore.py
+++ b/tripper/triplestore.py
@@ -580,8 +580,10 @@ class Triplestore:
             predicate: Possible criteria to match.
             object: Possible criteria to match.
             default: Value to return if no matches are found.
-            any: If true, return any matching value, otherwise raise
-                UniquenessError.
+            any: If True, return any matching value if there is more than one.
+                 If False, raise UniquenessError if there is more than one
+                 matching value.
+                 If None, return a generator over all matching values.
             lang: If provided, require that the value must be a localised
                 literal with the given language code.
 
@@ -607,25 +609,34 @@ class Triplestore:
             for triple in triples:
                 value = triple[idx]
                 if isinstance(value, Literal) and value.lang == lang:
-                    if any:
+                    if any is True:
                         return value
+                    if any is None:
+                        yield value
                     if first:
                         raise UniquenessError("More than one match")
                     first = value
             if first is None:
                 return default
+        elif any is None:
+            for triple in triples:
+                print("xxx0")
+                yield triple[idx]
         else:
             try:
                 triple = next(triples)
             except StopIteration:
+                print("xxx1")
                 return default
 
         try:
             next(triples)
         except StopIteration:
+            print("xxx2")
             return triple[idx]
 
         if any:
+            print("xxx3")
             return triple[idx]
         raise UniquenessError("More than one match")
 


### PR DESCRIPTION
# Description
Added option to Triplestore.value() to return a generator over all matching values. Also added more tests.

**Question**: Is there a better way to indicate that we should return all matches? Using `any=None` to indicate that is not very intuitive. But using a special value of the `any` argument is logical, since returning any match (`any=True`), returning all matches (`any=None`) and require only one match (`any=False`) are mutually exclusive.

## Type of change
- [ ] Bug fix and code cleanup
- [x] New feature
- [ ] Documentation update
- [x] Testing


## Checklist for the reviewer
This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
- [ ] Is the code properly tested?
