### PR TITLE
Include prefixes from context when populating a triplestore from a csv file

### DIFF
--- a/tests/datadoc/test_tabledoc.py
+++ b/tests/datadoc/test_tabledoc.py
@@ -178,6 +178,10 @@ def test_csv():
     ts.serialize(outdir / "semdata.ttl")
     print(ts.serialize())
 
+    # Test that prefixes are included in the serialisation
+    content = (outdir / "semdata.ttl").read_text()
+    assert "sem:SEMImageSeries" in content
+
 
 def test_csv_duplicated_columns():
     """Test CSV with duplicated columns."""

--- a/tripper/datadoc/dataset.py
+++ b/tripper/datadoc/dataset.py
@@ -99,7 +99,7 @@ class InvalidKeywordError(KeyError):
 def save_dict(
     ts: Triplestore,
     dct: dict,
-    type: str = "dataset",
+    type: "Optional[str]" = "dataset",
     prefixes: "Optional[dict]" = None,
     **kwargs,
 ) -> dict:

--- a/tripper/datadoc/tabledoc.py
+++ b/tripper/datadoc/tabledoc.py
@@ -67,7 +67,7 @@ class TableDoc:
         """Save tabular datadocumentation to triplestore."""
         self.prefixes.update(ts.namespaces)
         for d in self.asdicts():
-            save_dict(ts, d)
+            save_dict(ts, d, type=self.type, prefixes=self.prefixes)
 
     def asdicts(self) -> "List[dict]":
         """Return the table as a list of dicts."""

--- a/tripper/datadoc/tabledoc.py
+++ b/tripper/datadoc/tabledoc.py
@@ -74,7 +74,13 @@ class TableDoc:
         """Save tabular datadocumentation to triplestore."""
         self.prefixes.update(ts.namespaces)
         for d in self.asdicts():
-            save_dict(ts, d, type=self.type, prefixes=self.prefixes)
+            save_dict(
+                ts,
+                d,
+                type=self.type,
+                prefixes=self.prefixes,
+                _context=self.context,
+            )
 
     def asdicts(self) -> "List[dict]":
         """Return the table as a list of dicts."""

--- a/tripper/datadoc/tabledoc.py
+++ b/tripper/datadoc/tabledoc.py
@@ -7,7 +7,12 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from tripper import Triplestore
-from tripper.datadoc.dataset import addnested, as_jsonld, save_dict
+from tripper.datadoc.dataset import (
+    addnested,
+    as_jsonld,
+    get_prefixes,
+    save_dict,
+)
 from tripper.utils import AttrDict, openfile
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -59,7 +64,9 @@ class TableDoc:
         self.header = list(header)
         self.data = [list(row) for row in data]
         self.type = type
-        self.prefixes = prefixes if prefixes else {}
+        self.prefixes = get_prefixes(context=context)
+        if prefixes:
+            self.prefixes.update(prefixes)
         self.context = context if context else {}
         self.strip = strip
 


### PR DESCRIPTION
# Description
Include prefixes from context when populating a triplestore from a csv file.

Also made the `type` argument of `save_dict()` optional in order to be consistent with `as_jsonld()`.

## Type of change
- [x] Bug fix and code cleanup
- [ ] New feature
- [ ] Documentation update
- [ ] Testing


## Checklist for the reviewer
This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
- [ ] Is the code properly tested?
