### PR TITLE
Add updateEndpoint to SPARQLwrapper

### DIFF
--- a/tripper/backends/sparqlwrapper.py
+++ b/tripper/backends/sparqlwrapper.py
@@ -1,9 +1,9 @@
 """Backend for SPARQLWrapper"""
 
+import warnings
 from typing import TYPE_CHECKING
 
 from tripper import Literal
-import warnings
 
 try:
     from SPARQLWrapper import GET, JSON, POST, RDFXML, SPARQLWrapper

--- a/tripper/backends/sparqlwrapper.py
+++ b/tripper/backends/sparqlwrapper.py
@@ -48,7 +48,9 @@ class SparqlwrapperStrategy:
         kwargs.pop(
             "database", None
         )  # database is not used in the SPARQLWrapper backend
-        self.sparql = SPARQLWrapper(endpoint=base_iri, updateEndpoint=update_iri, **kwargs)
+        self.sparql = SPARQLWrapper(
+            endpoint=base_iri, updateEndpoint=update_iri, **kwargs
+        )
         if username and password:
             self.sparql.setCredentials(username, password)
 

--- a/tripper/backends/sparqlwrapper.py
+++ b/tripper/backends/sparqlwrapper.py
@@ -50,9 +50,15 @@ class SparqlwrapperStrategy:
             endpoint=base_iri, updateEndpoint=update_iri, **kwargs
         )
         import warnings
-        if not self.sparql.isSparqlUpdateRequest() and self.sparql.updateEndpoint is None:
-            warnings.warn("The 'base_iri' is not a valid update endpoint. "
-                    "For updates it is necessary to give the 'update_iri'.")
+
+        if (
+            not self.sparql.isSparqlUpdateRequest()
+            and self.sparql.updateEndpoint is None
+        ):
+            warnings.warn(
+                "The 'base_iri' is not a valid update endpoint. "
+                "For updates it is necessary to give the 'update_iri'."
+            )
         if username and password:
             self.sparql.setCredentials(username, password)
 

--- a/tripper/backends/sparqlwrapper.py
+++ b/tripper/backends/sparqlwrapper.py
@@ -26,7 +26,9 @@ class SparqlwrapperStrategy:
     """Triplestore strategy for SPARQLWrapper.
 
     Arguments:
-        base_iri: URI of SPARQL endpoint.
+        base_iri: SPARQL endpoint.
+        update_iri: Update SPARQL endpoint. For some triplestores (e.g.
+                    GraphDB), update endpoint is different from base endpoint.
         username: User name.
         password: Password.
         kwargs: Additional arguments passed to the SPARQLWrapper constructor.
@@ -38,6 +40,7 @@ class SparqlwrapperStrategy:
     def __init__(
         self,
         base_iri: str,
+        update_iri: "Optional[str]" = None,
         username: "Optional[str]" = None,
         password: "Optional[str]" = None,
         **kwargs,
@@ -45,7 +48,7 @@ class SparqlwrapperStrategy:
         kwargs.pop(
             "database", None
         )  # database is not used in the SPARQLWrapper backend
-        self.sparql = SPARQLWrapper(endpoint=base_iri, **kwargs)
+        self.sparql = SPARQLWrapper(endpoint=base_iri, updateEndpoint=update_iri, **kwargs)
         if username and password:
             self.sparql.setCredentials(username, password)
 

--- a/tripper/backends/sparqlwrapper.py
+++ b/tripper/backends/sparqlwrapper.py
@@ -3,6 +3,7 @@
 from typing import TYPE_CHECKING
 
 from tripper import Literal
+import warnings
 
 try:
     from SPARQLWrapper import GET, JSON, POST, RDFXML, SPARQLWrapper
@@ -49,8 +50,6 @@ class SparqlwrapperStrategy:
         self.sparql = SPARQLWrapper(
             endpoint=base_iri, updateEndpoint=update_iri, **kwargs
         )
-        import warnings
-
         if (
             not self.sparql.isSparqlUpdateRequest()
             and self.sparql.updateEndpoint is None

--- a/tripper/backends/sparqlwrapper.py
+++ b/tripper/backends/sparqlwrapper.py
@@ -49,6 +49,10 @@ class SparqlwrapperStrategy:
         self.sparql = SPARQLWrapper(
             endpoint=base_iri, updateEndpoint=update_iri, **kwargs
         )
+        import warnings
+        if not self.sparql.isSparqlUpdateRequest() and self.sparql.updateEndpoint is None:
+            warnings.warn("The 'base_iri' is not a valid update endpoint. "
+                    "For updates it is necessary to give the 'update_iri'.")
         if username and password:
             self.sparql.setCredentials(username, password)
 

--- a/tripper/backends/sparqlwrapper.py
+++ b/tripper/backends/sparqlwrapper.py
@@ -1,9 +1,9 @@
 """Backend for SPARQLWrapper"""
 
-import warnings
 from typing import TYPE_CHECKING
 
 from tripper import Literal
+from tripper.utils import TripperException
 
 try:
     from SPARQLWrapper import GET, JSON, POST, RDFXML, SPARQLWrapper
@@ -50,16 +50,23 @@ class SparqlwrapperStrategy:
         self.sparql = SPARQLWrapper(
             endpoint=base_iri, updateEndpoint=update_iri, **kwargs
         )
-        if (
-            not self.sparql.isSparqlUpdateRequest()
-            and self.sparql.updateEndpoint is None
-        ):
-            warnings.warn(
-                "The 'base_iri' is not a valid update endpoint. "
-                "For updates it is necessary to give the 'update_iri'."
-            )
         if username and password:
             self.sparql.setCredentials(username, password)
+
+        self.update_iri = update_iri
+
+    @property
+    def update_iri(self) -> "Optional[str]":
+        """Getter for the update IRI."""
+        return self._update_iri
+
+    @update_iri.setter
+    def update_iri(self, new_update_iri: "Optional[str]") -> None:
+        """Setter for the update IRI that also updates the SPARQL endpoint."""
+        self._update_iri = new_update_iri
+        # Update the SPARQLWrapper's updateEndpoint only if it was initialized.
+        if hasattr(self, "sparql"):
+            self.sparql.updateEndpoint = new_update_iri
 
     def query(
         self, query_object, **kwargs  # pylint: disable=unused-argument
@@ -128,6 +135,9 @@ class SparqlwrapperStrategy:
 
     def add_triples(self, triples: "Sequence[Triple]") -> "QueryResult":
         """Add a sequence of triples."""
+
+        self._check_endpoint()
+
         spec = "\n".join(
             "  "
             + " ".join(
@@ -149,6 +159,7 @@ class SparqlwrapperStrategy:
 
     def remove(self, triple: "Triple") -> "QueryResult":
         """Remove all matching triples from the backend."""
+        self._check_endpoint()
         spec = " ".join(
             (
                 f"?{name}"
@@ -166,6 +177,17 @@ class SparqlwrapperStrategy:
         self.sparql.setMethod(POST)
         self.sparql.setQuery(query)
         return self.sparql.query()
+
+    def _check_endpoint(self):
+        """Check if the update endpoint is valid"""
+        if not self.sparql.isSparqlUpdateRequest() and self.update_iri is None:
+            raise TripperException(
+                f"The base_iri '{self.sparql.updateEndpoint}' "
+                "is not a valid update endpoint. "
+                "For updates it is necessary to give the "
+                "'update_iri' as argument to the triplestore directly,"
+                "or update it with ts.backend.update_iri = ..."
+            )
 
 
 def convert_json_entrydict(entrydict: "Dict[str, str]") -> str:

--- a/tripper/utils.py
+++ b/tripper/utils.py
@@ -49,6 +49,14 @@ __all__ = (
 )
 
 
+class TripperException(Exception):
+    """A BaseException class for Tripper"""
+
+
+class TripperWarning(Warning):
+    """A BaseWarning class for Tripper"""
+
+
 class AttrDict(dict):
     """Dict with attribute access."""
 


### PR DESCRIPTION
# Description
Fixes the problem of having different URL for select and update queries, like in GraphDB.

```python
import tripper
from tripper import Literal

# CRASHES
#base_iri="http://GRAPHDB/repositories/TOPMAST"
#ts = tripper.Triplestore("sparqlwrapper", base_iri=base_iri)
#res = ts.add_triples([("<http://www.example.org/test1>", "<http://www.example.org/test3>", Literal("test3"))])
#res = ts.query("SELECT * WHERE { <http://www.example.org/test1> ?p ?o }")
#print(res)

#WORKS
select_iri="http://GRAPHDB/repositories/TOPMAST"
update_iri="http://GRAPHDB/repositories/TOPMAST/statements"

ts = tripper.Triplestore("sparqlwrapper", base_iri=update_iri)
res = ts.add_triples([("<http://www.example.org/test1>", "<http://www.example.org/test3>", Literal("test3"))])

ts = tripper.Triplestore("sparqlwrapper", base_iri=select_iri)
res = ts.query("SELECT * WHERE { <http://www.example.org/test1> ?p ?o }")
print(res)

#WITH THIS PR, update_iri keyword is added (optional)
ts = tripper.Triplestore("sparqlwrapper", base_iri=select_iri, update_iri=update_iri)
res = ts.add_triples([("<http://www.example.org/test1>", "<http://www.example.org/test3>", Literal("test3"))])
res = ts.query("SELECT * WHERE { <http://www.example.org/test1> ?p ?o }")
print(res)
```

## Type of change
- [ ] Bug fix and code cleanup
- [X] New feature
- [ ] Documentation update
- [ ] Testing


## Checklist for the reviewer
This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
- [ ] Is the code properly tested?
