### PR TITLE
disable pylint errors on too-many-positional-arguments

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,11 +45,11 @@ datadoc = [
 ]
 pre-commit = [
     "pre-commit==4.0.1",
-    "pylint==2.15.5",
+    "pylint==3.3.4",
 ]
 testing-core = [
-    "pytest==7.4.4",
-    "pytest-cov==4.1.0",
+    "pytest==8.3.4",
+    "pytest-cov==6.0.0",
 ]
 testing = [
     "tripper[testing-core,mappings,datadoc]",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,8 @@ pre-commit = [
 ]
 testing-core = [
     "pytest==8.3.4",
-    "pytest-cov==6.0.0",
+    "pytest-cov==5.0.0; python_version<'3.9'",
+    "pytest-cov==6.0.0; python_version>='3.9'",
 ]
 testing = [
     "tripper[testing-core,mappings,datadoc]",

--- a/tripper/backends/ontopy.py
+++ b/tripper/backends/ontopy.py
@@ -138,7 +138,7 @@ class OntopyStrategy:
                 self.onto._del_obj_triple_spo(s, p, o)
 
     # Optional methods
-    def parse(
+    def parse(  # pylint: disable=too-many-positional-arguments
         self,
         source=None,
         location=None,

--- a/tripper/backends/rdflib.py
+++ b/tripper/backends/rdflib.py
@@ -71,7 +71,7 @@ class RdflibStrategy:
 
     prefer_sparql = False
 
-    def __init__(
+    def __init__(  # pylint: disable=too-many-positional-arguments
         self,
         base_iri: "Optional[str]" = None,  # pylint: disable=unused-argument
         database: "Optional[str]" = None,

--- a/tripper/convert/convert.py
+++ b/tripper/convert/convert.py
@@ -188,7 +188,7 @@ def from_container(
     return rdf
 
 
-def save_container(
+def save_container(  # pylint: disable=too-many-positional-arguments
     ts: "Triplestore",
     container: "Union[Mapping[str, Any], Sequence[Any]]",
     iri: str,
@@ -330,7 +330,7 @@ def load_container(
 # === Deprecated functions ===
 
 
-def from_dict(
+def from_dict(  # pylint: disable=too-many-positional-arguments
     dct: dict,
     iri: str,
     bases: "Optional[Sequence]" = None,
@@ -367,7 +367,7 @@ def from_dict(
     )
 
 
-def save_dict(
+def save_dict(  # pylint: disable=too-many-positional-arguments
     ts: "Triplestore",
     dct: "Mapping[str, Any]",
     iri: str,

--- a/tripper/datadoc/dataaccess.py
+++ b/tripper/datadoc/dataaccess.py
@@ -12,6 +12,8 @@ Note:
     package.
 
 """
+from __future__ import annotations
+
 import secrets  # From Python 3.9 we could use random.randbytes(16).hex()
 from typing import TYPE_CHECKING
 from urllib.parse import urlparse
@@ -24,7 +26,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from typing import Any, Iterable, List, Mapping, Optional, Sequence, Union
 
 
-def save(
+def save(  # pylint: disable=too-many-positional-arguments
     ts: Triplestore,
     data: bytes,
     class_iri: "Optional[str]" = None,

--- a/tripper/datadoc/dataset.py
+++ b/tripper/datadoc/dataset.py
@@ -751,7 +751,7 @@ def as_jsonld(
     return d
 
 
-def get_partial_pipeline(
+def get_partial_pipeline(  # pylint: disable=too-many-positional-arguments
     ts: Triplestore,
     client,
     iri: str,

--- a/tripper/datadoc/tabledoc.py
+++ b/tripper/datadoc/tabledoc.py
@@ -52,7 +52,7 @@ class TableDoc:
 
     # pylint: disable=redefined-builtin,too-few-public-methods
 
-    def __init__(
+    def __init__(  # pylint: disable=too-many-positional-arguments
         self,
         header: "Sequence[str]",
         data: "Sequence[Sequence[str]]",
@@ -200,7 +200,7 @@ class TableDoc:
         )
 
     @staticmethod
-    def parse_csv(
+    def parse_csv(  # pylint: disable=too-many-positional-arguments
         csvfile: "Union[Iterable[str], Path, str]",
         type: "Optional[str]" = "dataset",
         prefixes: "Optional[dict]" = None,

--- a/tripper/mappings/mappings.py
+++ b/tripper/mappings/mappings.py
@@ -90,7 +90,7 @@ class Value:
 
     # pylint: disable=too-few-public-methods
 
-    def __init__(
+    def __init__(  # pylint: disable=too-many-positional-arguments
         self,
         value: "Any" = None,
         unit: "Optional[str]" = None,
@@ -204,7 +204,7 @@ class MappingStep:
 
     # pylint: disable=too-many-instance-attributes
 
-    def __init__(
+    def __init__(  # pylint: disable=too-many-positional-arguments
         self,
         output_iri: str,
         steptype: "StepType" = StepType.UNSPECIFIED,
@@ -757,7 +757,7 @@ def fno_mapper(triplestore: "Triplestore") -> "Dict[str, list]":
     return d
 
 
-def mapping_routes(
+def mapping_routes(  # pylint: disable=too-many-positional-arguments
     target: str,
     sources: "Union[Dict[str, Union[Value, None]], Sequence[str]]",
     triplestore: "Triplestore",

--- a/tripper/namespace.py
+++ b/tripper/namespace.py
@@ -56,7 +56,7 @@ class Namespace:
         "_format",  # Format to use when loading from a triplestore
     )
 
-    def __init__(
+    def __init__(  # pylint: disable=too-many-positional-arguments
         self,
         iri: str,
         label_annotations: "Union[Sequence, bool]" = (),

--- a/tripper/triplestore.py
+++ b/tripper/triplestore.py
@@ -228,7 +228,9 @@ class Triplestore:
         # Installed backend package
         if sys.version_info < (3, 10):
             # Fallback for Python < 3.10
-            eps = entry_points().get("tripper.backends", ())
+            eps = entry_points().get(  # pylint: disable=no-member
+                "tripper.backends", ()
+            )
         else:
             # New entry_point interface from Python 3.10+
             eps = entry_points(  # pylint: disable=unexpected-keyword-arg
@@ -611,7 +613,7 @@ class Triplestore:
         """Add `triple` to triplestore."""
         self.add_triples([triple])
 
-    def value(  # pylint: disable=redefined-builtin
+    def value(  # pylint: disable=redefined-builtin,too-many-positional-arguments
         self,
         subject=None,
         predicate=None,
@@ -822,7 +824,7 @@ class Triplestore:
         "value": (OWL.hasValue, None),
     }
 
-    def add_restriction(  # pylint: disable=redefined-builtin
+    def add_restriction(  # pylint: disable=redefined-builtin,too-many-positional-arguments
         self,
         cls: str,
         property: str,
@@ -884,7 +886,7 @@ class Triplestore:
         self.add_triples(triples)
         return iri
 
-    def restrictions(  # pylint: disable=redefined-builtin
+    def restrictions(  # pylint: disable=redefined-builtin,too-many-positional-arguments
         self,
         cls: "Optional[str]" = None,
         property: "Optional[str]" = None,
@@ -1025,7 +1027,7 @@ class Triplestore:
             target_cost=target_cost,
         )
 
-    def add_mapsTo(
+    def add_mapsTo(  # pylint: disable=too-many-positional-arguments
         self,
         target: str,
         source: str,
@@ -1169,7 +1171,7 @@ class Triplestore:
 
         return result
 
-    def add_function(
+    def add_function(  # pylint: disable=too-many-positional-arguments
         self,
         func: "Union[Callable, str]",
         expects: "Union[str, Sequence, Mapping]" = (),
@@ -1244,7 +1246,7 @@ class Triplestore:
 
         return func_iri
 
-    def _add_function_doc(
+    def _add_function_doc(  # pylint: disable=too-many-positional-arguments
         self,
         func_iri: "str",
         func: "Optional[Callable]" = None,

--- a/tripper/triplestore_extend.py
+++ b/tripper/triplestore_extend.py
@@ -36,7 +36,7 @@ class Tripper(Triplestore):
     such as get_value, add_data and add_interpolation_source.
     """
 
-    def add_data(
+    def add_data(  # pylint: disable=too-many-positional-arguments
         self,
         func: "Union[Callable, Literal]",
         iri: "Optional[Union[str, Sequence]]" = None,
@@ -121,7 +121,7 @@ class Tripper(Triplestore):
 
         return data_source
 
-    def get_value(
+    def get_value(  # pylint: disable=too-many-positional-arguments
         self,
         iri,
         routeno=0,
@@ -209,7 +209,7 @@ class Tripper(Triplestore):
             quantity=quantity,
         )
 
-    def add_interpolation_source(  # pylint: disable=too-many-arguments
+    def add_interpolation_source(  # pylint: disable=too-many-positional-arguments,too-many-arguments
         self,
         xcoord: str,
         ycoord: str,


### PR DESCRIPTION
# Description
This is done on an individual method level, to make sure that it is disabled correctly.

Unfortunately, pylint does not recognice the "" typechecking, and therefore thinks that key-word arguments are positional.

## Type of change
- [ ] Bug fix and code cleanup
- [ ] New feature
- [ ] Documentation update
- [ ] Testing


## Checklist for the reviewer
This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
- [ ] Is the code properly tested?
