### PR TITLE
Expand the IRI of @id in the dict returned by load_dict()

### DIFF
--- a/tests/backends/test_sparqlwrapper_graphdb.py
+++ b/tests/backends/test_sparqlwrapper_graphdb.py
@@ -133,12 +133,10 @@ ASK {
     # search for datasets in the graphDB
     datasets = search_iris(ts, type="dataset")
 
-    assert set(datasets) == set(
-        [
-            "https://onto-ns.com/datasets#our_nice_dataset",
-            "https://onto-ns.com/datasets#our_nice_dataset2",
-        ]
-    )
+    assert set(datasets) == {
+        "https://onto-ns.com/datasets#our_nice_dataset",
+        "https://onto-ns.com/datasets#our_nice_dataset2",
+    }
 
     retreived_info = load_dict(ts, datasets[0])
     assert retreived_info.creator == "Tripper-team"

--- a/tripper/datadoc/dataset.py
+++ b/tripper/datadoc/dataset.py
@@ -269,12 +269,13 @@ def load_dict(
 
 def _load_triples(ts: Triplestore, iri: str) -> dict:
     """Load `iri` from triplestore by calling `ts.triples()`."""
+    expanded_iri = ts.expand_iri(iri)
     shortnames = get_shortnames()
     dct: dict = {}
-    for p, o in ts.predicate_objects(ts.expand_iri(iri)):
+    for p, o in ts.predicate_objects(expanded_iri):
         add(dct, shortnames.get(p, p), as_python(o))
     if dct:
-        d = {"@id": iri}
+        d = {"@id": expanded_iri}
         d.update(dct)
         return d
     return dct


### PR DESCRIPTION
# Description
Expand the IRI of @id in the dict returned by load_dict(). 

This is a behaviour change. Is it really what we want? An alternative would be to add an option `expand_iri=False`. 

Applied on top of #340. Ensures that the sparql query works. 

## Type of change
- [x] Bug fix and code cleanup
- [x] New feature
- [ ] Documentation update
- [ ] Testing


## Checklist for the reviewer
This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
- [ ] Is the code properly tested?
