### PR TITLE
Added update() method to sparqlwrapper backend

### DIFF
--- a/tests/backends/datadocumentation_sample2.yaml
+++ b/tests/backends/datadocumentation_sample2.yaml
@@ -5,6 +5,6 @@ datasets:
   description: "This is a dataset description. I include:some strange characters to check that it does nåt crash anything."
   creator: Tripper-team
   contactPoint: Tripper-team
-  distribution.accessURL: https://onto-ns.com/datasets/our_nice_dataset22
+  distribution.accessURL: https://onto-ns.com/datasets/our_nice_dataset2
   distribution.mediaType: application/hdf5
   distribution.format: HDF5

--- a/tests/backends/datadocumentation_sample2.yaml
+++ b/tests/backends/datadocumentation_sample2.yaml
@@ -5,6 +5,6 @@ datasets:
   description: "This is a dataset description. I include:some strange characters to check that it does nåt crash anything."
   creator: Tripper-team
   contactPoint: Tripper-team
-  distribution.accessURL: https://onto-ns.com/datasets/our_nice_dataset2
+  distribution.accessURL: https://onto-ns.com/datasets/our_nice_dataset22
   distribution.mediaType: application/hdf5
   distribution.format: HDF5

--- a/tests/backends/test_sparqlwrapper_graphdb_fuseki.py
+++ b/tests/backends/test_sparqlwrapper_graphdb_fuseki.py
@@ -82,7 +82,7 @@ def get_triplestore(tsname: str) -> "Triplestore":
     return ts
 
 
-def populate_and_search(tsname):
+def populate_and_search(tsname):  # pylint: disable=too-many-statements
     """Do the test on the desried backend."""
     # Test adding triples
 
@@ -157,6 +157,8 @@ ASK {
     # Check that it raises NotImplementedError
     with pytest.raises(NotImplementedError):
         ts.query(query)
+    with pytest.raises(NotImplementedError):
+        ts.update(query)
 
     # Test DELETE query - clear the triplestore
     ts.update("DELETE WHERE { ?s ?p ?o . }")
@@ -166,6 +168,8 @@ ASK {
     # Check that it raises NotImplementedError
     with pytest.raises(NotImplementedError):
         ts.query(query)
+    with pytest.raises(NotImplementedError):
+        ts.update(query)
 
     # save a dataset to triplestore
     save_datadoc(ts, datasetinput)

--- a/tests/backends/test_sparqlwrapper_graphdb_fuseki.py
+++ b/tests/backends/test_sparqlwrapper_graphdb_fuseki.py
@@ -56,7 +56,33 @@ def fuseki_available():
         time.sleep(interval)
 
 
-def populate_and_search(ts):
+def get_triplestore(tsname: str) -> "Triplestore":
+    """Help function that returns a new triplestore object."""
+    from tripper import Triplestore
+
+    if tsname == "GraphDB":
+        ts = Triplestore(
+            backend="sparqlwrapper",
+            base_iri="http://localhost:7200/repositories/test_repo",
+            update_iri=(
+                "http://localhost:7200/repositories/test_repo/statements"
+            ),
+        )
+    elif tsname == "Fuseki":
+        ts = Triplestore(
+            backend="sparqlwrapper",
+            base_iri=f"{FUSEKI_CHECK_URL}/test_repo",
+            update_iri=f"{FUSEKI_CHECK_URL}/test_repo/update",
+            username="admin",
+            password="admin0",
+        )
+    else:
+        raise ValueError(f"Unsupported triplestore name: {tsname}")
+
+    return ts
+
+
+def populate_and_search(tsname):
     """Do the test on the desried backend."""
     # Test adding triples
 
@@ -68,6 +94,8 @@ def populate_and_search(ts):
     thisdir = Path(__file__).resolve().parent
     datasetinput = thisdir / "datadocumentation_sample.yaml"
     datasetinput2 = thisdir / "datadocumentation_sample2.yaml"
+
+    ts = get_triplestore(tsname)
 
     ts.add_triples(
         [
@@ -130,17 +158,20 @@ ASK {
     with pytest.raises(NotImplementedError):
         ts.query(query)
 
+    # Test DELETE query - clear the triplestore
+    ts.update("DELETE WHERE { ?s ?p ?o . }")
+
     # Test DESCRIBE query
     query = "DESCRIBE <http://www.example.org/subject>"
     # Check that it raises NotImplementedError
     with pytest.raises(NotImplementedError):
         ts.query(query)
 
-    # save a dataset to the graphDB
+    # save a dataset to triplestore
     save_datadoc(ts, datasetinput)
     save_datadoc(ts, datasetinput2)
 
-    # search for datasets in the graphDB
+    # search for datasets in triplestore
     datasets = search_iris(ts, type="dataset")
 
     print("Found datasets:")
@@ -184,6 +215,18 @@ ASK {
         ]
     )
 
+    # Test INSERT query
+    query = """
+PREFIX : <http://example.com#>
+INSERT DATA {
+    :sub :pred :obj .
+}
+"""
+    EX = ts.bind("ex", "http://example.com#")
+    ts.update(query)
+    triples = list(ts.triples(EX.sub))
+    assert triples == [(EX.sub, EX.pred, EX.obj)]
+
 
 def test_graphdb():
     """
@@ -193,17 +236,8 @@ def test_graphdb():
     if not graphdb_available():
         pytest.skip("GraphDB instance not available locally; skipping tests.")
 
-    from tripper import Triplestore
-
     print("Testing graphdb")
-
-    ts = Triplestore(
-        backend="sparqlwrapper",
-        base_iri="http://localhost:7200/repositories/test_repo",
-        update_iri="http://localhost:7200/repositories/test_repo/statements",
-    )
-
-    populate_and_search(ts)
+    populate_and_search("GraphDB")
 
 
 def test_fuseki():
@@ -214,16 +248,5 @@ def test_fuseki():
     if not fuseki_available():
         pytest.skip("Fuseki instance not available locally; skipping tests.")
 
-    from tripper import Triplestore
-
     print("Testing fuseki")
-
-    ts = Triplestore(
-        backend="sparqlwrapper",
-        base_iri=f"{FUSEKI_CHECK_URL}/test_repo",
-        update_iri=f"{FUSEKI_CHECK_URL}/test_repo/update",
-        username="admin",
-        password="admin0",
-    )
-
-    populate_and_search(ts)
+    populate_and_search("Fuseki")

--- a/tripper/backends/sparqlwrapper.py
+++ b/tripper/backends/sparqlwrapper.py
@@ -73,7 +73,9 @@ class SparqlwrapperStrategy:
             self.sparql.updateEndpoint = new_update_iri
 
     def query(
-        self, query_object, **kwargs  # pylint: disable=unused-argument
+        self,
+        query_object: str,
+        **kwargs,  # pylint: disable=unused-argument
     ) -> "Union[List[Tuple[str, ...]], bool, Generator[Triple, None, None]]":
         """SPARQL query.
 

--- a/tripper/backends/sparqlwrapper.py
+++ b/tripper/backends/sparqlwrapper.py
@@ -142,7 +142,7 @@ class SparqlwrapperStrategy:
         """Update triplestore with SPARQL query.
 
         Arguments:
-            query_object: String with the SPARQL query.
+            update_object: String with the SPARQL query.
             kwargs: Additional backend-specific keyword arguments.
 
         Note:

--- a/tripper/backends/sparqlwrapper.py
+++ b/tripper/backends/sparqlwrapper.py
@@ -123,13 +123,38 @@ class SparqlwrapperStrategy:
         # either the beginning of the string or following a newline
         # or a period. It then matches one of the keywords.
         pattern = re.compile(
-            r"(?:(?<=^)|(?<=[\.\n]))\s*(ASK|CONSTRUCT|SELECT|DESCRIBE)\b",
+            r"(?:(?<=^)|(?<=[\.\n]))\s*(ASK|CONSTRUCT|SELECT|DESCRIBE|"
+            r"DELETE|INSERT)\b",
             re.IGNORECASE,
         )
         match = pattern.search(query)
         if match:
             return match.group(1).upper()
         return "UNKNOWN"
+
+    def update(
+        self,
+        update_object: str,
+        **kwargs,  # pylint: disable=unused-argument
+    ) -> None:
+        """Update triplestore with SPARQL quary.
+
+        Arguments:
+            query_object: String with the SPARQL query.
+            kwargs: Additional backend-specific keyword arguments.
+
+        Note:
+            This method is intended for INSERT and DELETE queries.  Use
+            the query() method for ASK/CONSTRUCT/SELECT/DESCRIBE queries.
+        """
+        query_type = self._get_sparql_query_type(update_object)
+        if query_type not in ("DELETE", "INSERT"):
+            raise NotImplementedError(
+                f"Update query type '{query_type}' not implemented."
+            )
+        self.sparql.setMethod(POST)
+        self.sparql.setQuery(update_object)
+        return self.sparql.query()
 
     def triples(self, triple: "Triple") -> "Generator[Triple, None, None]":
         """Returns a generator over matching triples."""

--- a/tripper/backends/sparqlwrapper.py
+++ b/tripper/backends/sparqlwrapper.py
@@ -154,7 +154,7 @@ class SparqlwrapperStrategy:
             )
         self.sparql.setMethod(POST)
         self.sparql.setQuery(update_object)
-        return self.sparql.query()
+        self.sparql.query()
 
     def triples(self, triple: "Triple") -> "Generator[Triple, None, None]":
         """Returns a generator over matching triples."""


### PR DESCRIPTION
# Description
Added update() method to sparqlwrapper backend supporting both INSERT and DELETE queries. 

Other fixes:
- fixed failing test by empty the triplestore as the first thing in the test 
- made it easier to run the populate_and_search() test in `test_sqarqlwrapper_graphdb_fuseki.py` without pytest.

## Type of change
- [ ] Bug fix and code cleanup
- [x] New feature
- [ ] Documentation update
- [x] Testing


## Checklist for the reviewer
This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
- [ ] Is the code properly tested?
