### PR TITLE
Improved control when storing to the triplestore

### DIFF
--- a/docs/datadoc/customisation.md
+++ b/docs/datadoc/customisation.md
@@ -13,7 +13,7 @@ Tripper already include a default list of [predefined prefixes].
 Additional prefixed can be provided in two ways.
 
 ### With the `prefixes` argument
-Several functions in the API (like [save_dict()], [told()] and [TableDoc.parse_csv()]) takes a `prefixes` argument with which additional namespace prefixes can provided.
+Several functions in the API (like [store()], [told()] and [TableDoc.parse_csv()]) takes a `prefixes` argument with which additional namespace prefixes can provided.
 
 This may be handy when used from the Python API.
 
@@ -242,7 +242,7 @@ Instead, the list of available resource types should be stored and retrieved fro
 [predefined prefixes]: prefixes.md
 [predefined keywords]: keywords.md
 [default context]: https://raw.githubusercontent.com/EMMC-ASBL/tripper/refs/heads/master/tripper/context/0.2/context.json
-[save_dict()]: ../api_reference/datadoc/dataset.md#tripper.datadoc.dataset.save_dict
+[store()]: ../api_reference/datadoc/dataset.md#tripper.datadoc.dataset.store
 [told()]: ../api_reference/datadoc/dataset.md#tripper.datadoc.dataset.told
 [save_datadoc()]: ../api_reference/datadoc/dataset.md#tripper.datadoc.dataset.save_datadoc
 [TableDoc]: ../api_reference/datadoc/tabledoc.md/#tripper.datadoc.tabledoc.TableDoc

--- a/docs/datadoc/documenting-a-resource.md
+++ b/docs/datadoc/documenting-a-resource.md
@@ -77,14 +77,14 @@ We therefore have to define them explicitly
     }
     ```
 
-You can use [save_dict()] to save this documentation to a triplestore.
+You can use [store()] to save this documentation to a triplestore.
 Since the prefixes "sem" and "kb" are not included in the [Predefined prefixes], they are have to be provided explicitly.
 
 ```python
 >>> from tripper import Triplestore
->>> from tripper.datadoc import save_dict
+>>> from tripper.datadoc import store
 >>> ts = Triplestore(backend="rdflib")
->>> d = save_dict(ts, dataset, prefixes=prefixes)
+>>> d = store(ts, dataset, prefixes=prefixes)
 
 ```
 
@@ -119,7 +119,7 @@ kb:image1 a sem:SEMImage ;
 ```
 
 Note that the image implicitly has been declared to be an individual of the classes `dcat:Dataset` and `emmo:Dataset`.
-This is because the `type` argument of [save_dict()] defaults to "dataset".
+This is because the `type` argument of [store()] defaults to "dataset".
 
 
 ### Multi-resource dict
@@ -215,7 +215,7 @@ The below example shows how to save all datasets listed in the CSV file [semdata
 [emmo:Dataset]: https://w3id.org/emmo#EMMO_194e367c_9783_4bf5_96d0_9ad597d48d9a
 [oteio:Generator]: https://w3id.org/emmo/domain/oteio/Generator
 [oteio:Parser]: https://w3id.org/emmo/domain/oteio/Parser
-[save_dict()]: ../api_reference/datadoc/dataset.md/#tripper.datadoc.dataset.save_dict
+[store()]: ../api_reference/datadoc/dataset.md/#tripper.datadoc.dataset.store
 [told()]: ../api_reference/datadoc/dataset.md/#tripper.datadoc.dataset.told
 [save_datadoc()]:
 ../api_reference/datadoc/dataset.md/#tripper.datadoc.dataset.save_datadoc

--- a/docs/datadoc/introduction.md
+++ b/docs/datadoc/introduction.md
@@ -58,7 +58,7 @@ Future releases will support adding custom resource types.
 [emmo:Dataset]: https://w3id.org/emmo#EMMO_194e367c_9783_4bf5_96d0_9ad597d48d9a
 [oteio:Generator]: https://w3id.org/emmo/domain/oteio/Generator
 [oteio:Parser]: https://w3id.org/emmo/domain/oteio/Parser
-[save_dict()]: ../../api_reference/datadoc/dataset/#tripper.datadoc.dataset.save_dict
+[store()]: ../../api_reference/datadoc/dataset/#tripper.datadoc.dataset.store
 [as_jsonld()]: ../../api_reference/datadoc/dataset/#tripper.datadoc.dataset.as_jsonld
 [save_datadoc()]:
 ../../api_reference/datadoc/dataset/#tripper.datadoc.dataset.save_datadoc

--- a/docs/datadoc/keywords.md
+++ b/docs/datadoc/keywords.md
@@ -14,13 +14,14 @@ The meaning of the columns are as follows:
 ## Special keywords (from JSON-LD)
 See the [JSON-LD specification] for more details.
 
-| Keyword    | Range         | Conformance | Definition                                                   | Usage note |
-|------------|---------------|-------------|--------------------------------------------------------------|------------|
-| [@id]      | IRI           | mandatory   | IRI identifying the resource to document.                    |            |
-| [@type]    | IRI           | recommended | Ontological class defining the class of a node.              |            |
-| [@context] | dict&#124list | optional    | Context defining namespace prefixes and additional keywords. |            |
-| [@base]    | list          | optional    | Base IRI against which relative IRIs are resolved.           |            |
-| [@graph]   | list          | optional    | Used for documenting multiple resources.                     |            |
+| Keyword    | Range         | Conformance | Definition                                                              | Usage note |
+|------------|---------------|-------------|-------------------------------------------------------------------------|------------|
+| [@id]      | IRI           | mandatory   | IRI identifying the resource to document.                               |            |
+| [@type]    | IRI           | recommended | Ontological class defining the class of a node.                         |            |
+| [@context] | dict&#124list | optional    | Context defining namespace prefixes and additional keywords.            |            |
+| [@base]    | namespace     | optional    | Base IRI against which relative IRIs are resolved.                      |            |
+| [@vocab]   | namespace     | optional    | Used to expand properties and values in @type with a common prefix IRI. |            |
+| [@graph]   | list          | optional    | Used for documenting multiple resources.                                |            |
 
 
 ## Properties on [Resource]
@@ -533,4 +534,5 @@ A generic resource.
 [@type]: https://www.w3.org/TR/json-ld11/#syntax-tokens-and-keywords
 [@context]: https://www.w3.org/TR/json-ld11/#syntax-tokens-and-keywords
 [@base]: https://www.w3.org/TR/json-ld11/#syntax-tokens-and-keywords
+[@vocab]: https://www.w3.org/TR/json-ld11/#syntax-tokens-and-keywords
 [@graph]: https://www.w3.org/TR/json-ld11/#syntax-tokens-and-keywords

--- a/docs/datadoc/keywords.md
+++ b/docs/datadoc/keywords.md
@@ -11,6 +11,17 @@ The meaning of the columns are as follows:
 - **Definition**: The definition of the keyword.
 - **Usage note**: Notes about how to use the keyword.
 
+## Special keywords (from JSON-LD)
+See the [JSON-LD specification] for more details.
+
+| Keyword    | Range         | Conformance | Definition                                                   | Usage note |
+|------------|---------------|-------------|--------------------------------------------------------------|------------|
+| [@id]      | IRI           | mandatory   | IRI identifying the resource to document.                    |            |
+| [@type]    | IRI           | recommended | Ontological class defining the class of a node.              |            |
+| [@context] | dict&#124list | optional    | Context defining namespace prefixes and additional keywords. |            |
+| [@base]    | list          | optional    | Base IRI against which relative IRIs are resolved.           |            |
+| [@graph]   | list          | optional    | Used for documenting multiple resources.                     |            |
+
 
 ## Properties on [Resource]
 Resource published or curated by an agent.
@@ -518,3 +529,8 @@ A generic resource.
 [Standard]: http://purl.org/dc/terms/Standard
 [MediaType]: http://purl.org/dc/terms/MediaType
 [GenericResource]: http://www.w3.org/2000/01/rdf-schema#Resource
+[@id]: https://www.w3.org/TR/json-ld11/#syntax-tokens-and-keywords
+[@type]: https://www.w3.org/TR/json-ld11/#syntax-tokens-and-keywords
+[@context]: https://www.w3.org/TR/json-ld11/#syntax-tokens-and-keywords
+[@base]: https://www.w3.org/TR/json-ld11/#syntax-tokens-and-keywords
+[@graph]: https://www.w3.org/TR/json-ld11/#syntax-tokens-and-keywords

--- a/docs/datadoc/prefixes.md
+++ b/docs/datadoc/prefixes.md
@@ -28,5 +28,5 @@ See [User-defined prefixes] for how to extend this list with additional namespac
 | chameo  | https://w3id.org/emmo/domain/characterisation-methodology/chameo# |
 
 
-[default JSON-LD context]: https://raw.githubusercontent.com/EMMC-ASBL/tripper/refs/heads/master/tripper/context/0.2/context.json
+[default JSON-LD context]: https://raw.githubusercontent.com/EMMC-ASBL/tripper/refs/heads/master/tripper/context/0.3/context.json
 [User-defined prefixes]: customisation.md/#user-defined-prefixes

--- a/tests/backends/test_sparqlwrapper_graphdb_fuseki.py
+++ b/tests/backends/test_sparqlwrapper_graphdb_fuseki.py
@@ -47,7 +47,7 @@ def populate_and_search(tsname):  # pylint: disable=too-many-statements
     from pathlib import Path
 
     from tripper import Literal
-    from tripper.datadoc import load_dict, save_datadoc, search
+    from tripper.datadoc import acquire, save_datadoc, search
 
     thisdir = Path(__file__).resolve().parent
     datasetinput = thisdir / "datadocumentation_sample.yaml"
@@ -146,7 +146,7 @@ ASK {
         ]
     )
 
-    retreived_info = load_dict(ts, datasets[0])
+    retreived_info = acquire(ts, datasets[0])
     # print("Info on one dataset")
     # print(retreived_info)
     assert retreived_info.creator.name == "Tripper-team"
@@ -156,7 +156,7 @@ ASK {
     )
 
     ts.bind("dataset", "https://onto-ns.com/datasets#")
-    retreived_info_2 = load_dict(ts, f"dataset:{datasets[0].split('#')[-1]}")
+    retreived_info_2 = acquire(ts, f"dataset:{datasets[0].split('#')[-1]}")
     # print(retreived_info_2)
     assert retreived_info_2.creator.name == "Tripper-team"
     assert (

--- a/tests/backends/test_sparqlwrapper_graphdb_fuseki.py
+++ b/tests/backends/test_sparqlwrapper_graphdb_fuseki.py
@@ -47,7 +47,7 @@ def populate_and_search(tsname):  # pylint: disable=too-many-statements
     from pathlib import Path
 
     from tripper import Literal
-    from tripper.datadoc import load_dict, save_datadoc, search_iris
+    from tripper.datadoc import load_dict, save_datadoc, search
 
     thisdir = Path(__file__).resolve().parent
     datasetinput = thisdir / "datadocumentation_sample.yaml"
@@ -135,7 +135,7 @@ ASK {
     save_datadoc(ts, datasetinput2)
 
     # search for datasets in triplestore
-    datasets = search_iris(ts, type="Dataset")
+    datasets = search(ts, type="Dataset")
 
     print("Found datasets:")
     print(datasets)
@@ -168,7 +168,7 @@ ASK {
 
     ts.remove(subject="https://onto-ns.com/datasets#our_nice_dataset2")
 
-    datasets3 = search_iris(ts, type="Dataset")
+    datasets3 = search(ts, type="Dataset")
 
     print("Found datasets after deletion:")
     print(datasets3)

--- a/tests/datadoc/test_dataaccess.py
+++ b/tests/datadoc/test_dataaccess.py
@@ -65,7 +65,7 @@ def test_save_and_load():
     )
 
     # Test load dataset (this downloads an actual image from github)
-    data = load(ts, iri)
+    data = load(ts, iri, retries=3)
     assert len(data) == 53502
 
     # Test save dataset with anonymous distribution

--- a/tests/datadoc/test_dataaccess.py
+++ b/tests/datadoc/test_dataaccess.py
@@ -108,6 +108,7 @@ def test_save_and_load():
             "generator": GEN.sem_hitachi,
             "parser": PARSER.sem_hitachi,
         },
+        method="overwrite",
     )
     assert newfile2.exists()
     assert newfile2.stat().st_size == len(buf)

--- a/tests/datadoc/test_dataaccess.py
+++ b/tests/datadoc/test_dataaccess.py
@@ -15,7 +15,7 @@ def test_save_and_load():
     from dataset_paths import outdir  # pylint: disable=import-error
 
     from tripper import DCAT, DCTERMS, EMMO, Triplestore
-    from tripper.datadoc import load, load_dict, save, save_dict
+    from tripper.datadoc import acquire, load, save, store
 
     pytest.importorskip("dlite")
     pytest.importorskip("rdflib")
@@ -30,7 +30,7 @@ def test_save_and_load():
     iri = SEMDATA.img1
 
     # Test save dict
-    save_dict(
+    store(
         ts,
         source={
             "@id": SEMDATA.img1,
@@ -46,7 +46,7 @@ def test_save_and_load():
         },
         type="Dataset",
     )
-    newdistr = load_dict(ts, SEMDATA.img1)
+    newdistr = acquire(ts, SEMDATA.img1)
     assert newdistr["@type"] == [DCAT.Dataset, DCAT.Resource, EMMO.Dataset]
     assert newdistr.distribution["@type"] == [DCAT.Distribution, DCAT.Resource]
     assert (
@@ -54,7 +54,7 @@ def test_save_and_load():
         == "http://www.iana.org/assignments/media-types/image/tiff"
     )
 
-    save_dict(
+    store(
         ts,
         source={
             "@id": GEN.sem_hitachi,
@@ -84,7 +84,7 @@ def test_save_and_load():
     )
     assert newfile.exists()
     assert newfile.stat().st_size == len(buf)
-    newimage = load_dict(ts, SEMDATA.newimage)
+    newimage = acquire(ts, SEMDATA.newimage)
     assert newimage["@id"] == SEMDATA.newimage
     assert DCAT.Dataset in newimage["@type"]
     assert SEM.SEMImage in newimage["@type"]
@@ -112,12 +112,12 @@ def test_save_and_load():
     )
     assert newfile2.exists()
     assert newfile2.stat().st_size == len(buf)
-    newimage2 = load_dict(ts, SEMDATA.newimage2)
+    newimage2 = acquire(ts, SEMDATA.newimage2)
     assert newimage2["@id"] == SEMDATA.newimage2
     assert newimage2["@type"] == [DCAT.Dataset, DCAT.Resource, EMMO.Dataset]
     assert newimage2.distribution == SEMDATA.newdistr2
 
-    newdist2 = load_dict(ts, newimage2.distribution)
+    newdist2 = acquire(ts, newimage2.distribution)
     assert newdist2["@id"] == newimage2.distribution
     assert newdist2["@type"] == [DCAT.Distribution, DCAT.Resource]
     assert newdist2.downloadURL == f"file:{newfile2}"

--- a/tests/datadoc/test_dataaccess.py
+++ b/tests/datadoc/test_dataaccess.py
@@ -153,7 +153,7 @@ def test_save_and_load():
     assert newfile2.exists()
     assert newfile2.stat().st_size == len(buf)
 
-    # Test save dataset with invalid downloadURL
+    # Test save and load dataset with invalid downloadURL
     store(
         ts,
         source={

--- a/tests/datadoc/test_dataaccess.py
+++ b/tests/datadoc/test_dataaccess.py
@@ -148,3 +148,7 @@ def test_save_and_load():
     )
     assert newfile2.exists()
     assert newfile2.stat().st_size == len(buf)
+
+    # Test load failure
+    with pytest.raises(TypeError):
+        load(ts, "<nonexisting>", retries=2)

--- a/tests/datadoc/test_datadoc_cli.py
+++ b/tests/datadoc/test_datadoc_cli.py
@@ -157,6 +157,42 @@ def test_find_json():
     assert len(resources) == 3
 
 
+def test_find_turtle():
+    """Test `datadoc find` with Fuseki."""
+    from dataset_paths import indir  # pylint: disable=import-error
+
+    cmd = [
+        "--debug",
+        "--triplestore=FusekiTest",
+        f"--config={indir/'session.yaml'}",
+        "find",
+        "--criteria=creator.name=Sigurd Wenner",
+        "--format=turtle",
+    ]
+    r = maincommand(cmd)
+    assert "<https://he-matchmaker.eu/data/sem/SEM_cement_batch2>" in r
+
+
+def test_find_csv():
+    """Test `datadoc find` with Fuseki."""
+    from dataset_paths import indir  # pylint: disable=import-error
+
+    cmd = [
+        "--debug",
+        "--triplestore=FusekiTest",
+        f"--config={indir/'session.yaml'}",
+        "find",
+        "--criteria=creator.name=Sigurd Wenner",
+        "--format=csv",
+    ]
+    r = maincommand(cmd)
+    lines = r.split("\n")
+    assert "@id" in lines[0]
+    assert "@type" in lines[0]
+    assert "description" in lines[0]
+    assert len(lines) == 5
+
+
 def test_fetch():
     """Test `datadoc fetch` with Fuseki."""
     from dataset_paths import indir, outdir  # pylint: disable=import-error

--- a/tests/datadoc/test_dataset.py
+++ b/tests/datadoc/test_dataset.py
@@ -298,11 +298,11 @@ def test_get():
     assert get(d, "c", default="x", aslist=False) == "x"
 
 
-# if True:
-def test_save_dict():
+def test_store():
     """Test save_dict()."""
     from tripper import Triplestore
-    from tripper.datadoc import save_dict
+    from tripper.datadoc import acquire, store
+    from tripper.datadoc.errors import IRIExistsError
 
     ts = Triplestore("rdflib")
     EX = ts.bind("ex", "http://example.com/ex#")
@@ -318,8 +318,23 @@ def test_save_dict():
             ),
         },
     }
-    save_dict(ts, d, type="Dataset")
+    store(ts, d, type="Dataset")
     print(ts.serialize())
+
+    with pytest.raises(IRIExistsError):
+        store(ts, d, type="Dataset")
+
+    d1 = acquire(ts, EX.exdata)
+    assert isinstance(d1.distribution, dict)
+
+    store(ts, d, type="Dataset", method="overwrite")
+    d2 = acquire(ts, EX.exdata)
+    assert isinstance(d2.distribution, dict)
+    assert d2.distribution.downloadURL == d1.distribution.downloadURL
+
+    store(ts, d, type="Dataset", method="merge")
+    d3 = acquire(ts, EX.exdata)
+    assert isinstance(d3.distribution, list)
 
 
 def test_datadoc():

--- a/tests/datadoc/test_dataset.py
+++ b/tests/datadoc/test_dataset.py
@@ -24,7 +24,7 @@ def test_told():
     from pathlib import Path
 
     from tripper import DCAT, DCTERMS, OWL, RDF, Literal, Triplestore
-    from tripper.datadoc.dataset import save_dict, told
+    from tripper.datadoc.dataset import store, told
 
     indir = Path(__file__).resolve().parent.parent / "input"
     prefixes = {"ex": "http://example.com/ex#"}
@@ -62,9 +62,9 @@ def test_told():
         ),
     }
 
-    # Test save_dict()on descrA
-    save_dict(ts, descrA, prefixes=prefixes)
-    EX = ts.namespaces["ex"]  # save_dict() adds the namespace to `ts`
+    # Test store() on descrA
+    store(ts, descrA, prefixes=prefixes)
+    EX = ts.namespaces["ex"]  # store() adds the namespace to `ts`
     assert ts.has(EX.a, RDF.type, EX.A)
     # assert ts.has(EX.a, RDF.type, EX.TechnicalDataset)
 
@@ -123,10 +123,10 @@ def test_told():
     ]
     assert d4["@graph"][1]["@type"] == "owl:NamedIndividual"
 
-    # Test save_dict()on descrB
+    # Test store() on descrB
     ts.remove()
-    save_dict(ts, descrB, prefixes=prefixes)
-    EX = ts.namespaces["ex"]  # save_dict() adds the namespace to `ts`
+    store(ts, descrB, prefixes=prefixes)
+    EX = ts.namespaces["ex"]  # store() adds the namespace to `ts`
     assert ts.has(EX.a, DCAT.distribution)
     assert ts.has(EX.a, DCTERMS.title, Literal("Dataset a"))
 
@@ -148,10 +148,10 @@ def test_told():
     d5 = told(descrC)
     assert d5 == d4
 
-    # Test save_dict() on descrC
+    # Test store() on descrC
     ts.remove()
-    save_dict(ts, descrB, prefixes=prefixes)
-    EX = ts.namespaces["ex"]  # save_dict() adds the namespace to `ts`
+    store(ts, descrB, prefixes=prefixes)
+    EX = ts.namespaces["ex"]  # store() adds the namespace to `ts`
     assert ts.has(EX.a, DCAT.distribution)
     assert ts.has(EX.a, DCTERMS.title, Literal("Dataset a"))
 
@@ -187,10 +187,10 @@ def test_told():
         "emmo:EMMO_194e367c_9783_4bf5_96d0_9ad597d48d9a",
     ]
 
-    # Test save_dict() on descrC
+    # Test store() on descrC
     ts.remove()
-    save_dict(ts, descrB, prefixes=prefixes)
-    EX = ts.namespaces["ex"]  # save_dict() adds the namespace to `ts`
+    store(ts, descrB, prefixes=prefixes)
+    EX = ts.namespaces["ex"]  # store() adds the namespace to `ts`
     assert ts.has(EX.a, DCAT.distribution)
     assert ts.has(EX.a, DCTERMS.title, Literal("Dataset a"))
     assert ts.has(EX.a, RDF.type, EX.A)
@@ -299,10 +299,10 @@ def test_get():
 
 
 def test_store():
-    """Test save_dict()."""
+    """Test store()."""
     from tripper import Triplestore
     from tripper.datadoc import acquire, store
-    from tripper.datadoc.errors import IRIExistsError
+    from tripper.datadoc.errors import IRIExistsError, IRIExistsWarning
 
     ts = Triplestore("rdflib")
     EX = ts.bind("ex", "http://example.com/ex#")
@@ -332,22 +332,28 @@ def test_store():
     assert isinstance(d2.distribution, dict)
     assert d2.distribution.downloadURL == d1.distribution.downloadURL
 
-    store(ts, d, type="Dataset", method="merge")
+    with pytest.warns(IRIExistsWarning):
+        store(ts, d, type="Dataset", method="ignore")
     d3 = acquire(ts, EX.exdata)
-    assert isinstance(d3.distribution, list)
+    assert isinstance(d3.distribution, dict)
+    assert d3.distribution.downloadURL == d1.distribution.downloadURL
+
+    store(ts, d, type="Dataset", method="merge")
+    d4 = acquire(ts, EX.exdata)
+    assert isinstance(d4.distribution, list)
 
     with pytest.raises(ValueError):
         store(ts, d, type="Dataset", method="invalid_method_name")
 
 
 def test_datadoc():
-    """Test save_datadoc() and load_dict()/save_dict()."""
+    """Test save_datadoc() and acquire()/store()."""
     # pylint: disable=too-many-statements
 
     from dataset_paths import indir  # pylint: disable=import-error
 
     from tripper import CHAMEO, DCAT, EMMO, OTEIO, Triplestore
-    from tripper.datadoc import load_dict, save_datadoc, save_dict, search_iris
+    from tripper.datadoc import acquire, save_datadoc, search_iris, store
     from tripper.datadoc.errors import NoSuchTypeError
 
     pytest.importorskip("dlite")
@@ -364,7 +370,7 @@ def test_datadoc():
     SEM = ts.namespaces["sem"]
     SEMDATA = ts.namespaces["semdata"]
     iri = SEMDATA["SEM_cement_batch2/77600-23-001/77600-23-001_5kV_400x_m001"]
-    d = load_dict(ts, iri, use_sparql=False)
+    d = acquire(ts, iri, use_sparql=False)
     assert d["@id"] == iri
     assert set(d["@type"]) == {
         DCAT.Dataset,
@@ -378,16 +384,16 @@ def test_datadoc():
         "http://www.iana.org/assignments/media-types/image/tiff"
     )
 
-    assert not load_dict(ts, "non-existing")
-    assert not load_dict(ts, "non-existing", use_sparql=True)
+    assert not acquire(ts, "non-existing")
+    assert not acquire(ts, "non-existing", use_sparql=True)
 
     # Test load using SPARQL - this should give the same result as above
-    d2 = load_dict(ts, iri, use_sparql=True)
+    d2 = acquire(ts, iri, use_sparql=True)
     assert d2 == d
 
     # Test loading a parser
     PAR = ts.namespaces["par"]
-    parser = load_dict(ts, PAR.sem_hitachi)
+    parser = acquire(ts, PAR.sem_hitachi)
     assert parser["@id"] == PAR.sem_hitachi
     assert parser["@type"] == OTEIO.Parser
     assert parser.configuration == {"driver": "hitachi"}
@@ -399,16 +405,16 @@ def test_datadoc():
     ts.add((d.distribution["@id"], OTEIO.generator, GEN.sem_hitachi))
 
     # Test saving a generator and add it to the distribution
-    dist = load_dict(ts, d.distribution["@id"])
+    dist = acquire(ts, d.distribution["@id"])
     assert dist.generator == GEN.sem_hitachi
 
-    gen = load_dict(ts, dist.generator)
+    gen = acquire(ts, dist.generator)
     assert gen["@id"] == GEN.sem_hitachi
     assert gen["@type"] == [OTEIO.Generator, OTEIO.Parser]
     assert gen.generatorType == "application/vnd.dlite-generate"
 
     # Test save dict
-    save_dict(
+    store(
         ts,
         source={
             "@id": SEMDATA.newdistr,
@@ -419,7 +425,7 @@ def test_datadoc():
         type="Distribution",
         prefixes={"echem": "https://w3id.org/emmo/domain/electrochemistry"},
     )
-    newdistr = load_dict(ts, SEMDATA.newdistr)
+    newdistr = acquire(ts, SEMDATA.newdistr)
     assert newdistr["@type"] == [DCAT.Distribution, DCAT.Resource]
     assert (
         newdistr.mediaType
@@ -427,7 +433,7 @@ def test_datadoc():
     )
 
     # Test load updated distribution
-    dd = load_dict(ts, iri)
+    dd = acquire(ts, iri)
     assert dd.distribution.generator == GEN.sem_hitachi
     del dd.distribution["generator"]
     assert dd == d

--- a/tests/datadoc/test_dataset.py
+++ b/tests/datadoc/test_dataset.py
@@ -336,6 +336,9 @@ def test_store():
     d3 = acquire(ts, EX.exdata)
     assert isinstance(d3.distribution, list)
 
+    with pytest.raises(ValueError):
+        store(ts, d, type="Dataset", method="invalid_method_name")
+
 
 def test_datadoc():
     """Test save_datadoc() and load_dict()/save_dict()."""

--- a/tests/datadoc/test_dataset.py
+++ b/tests/datadoc/test_dataset.py
@@ -353,7 +353,7 @@ def test_datadoc():
     from dataset_paths import indir  # pylint: disable=import-error
 
     from tripper import CHAMEO, DCAT, EMMO, OTEIO, Triplestore
-    from tripper.datadoc import acquire, save_datadoc, search_iris, store
+    from tripper.datadoc import acquire, save_datadoc, search, store
     from tripper.datadoc.errors import NoSuchTypeError
 
     pytest.importorskip("dlite")
@@ -440,8 +440,8 @@ def test_datadoc():
 
     # Test searching the triplestore
     SAMPLE = ts.namespaces["sample"]
-    datasets = search_iris(ts, type="Dataset")
-    assert search_iris(ts, type="dcat:Dataset") == datasets
+    datasets = search(ts, type="Dataset")
+    assert search(ts, type="dcat:Dataset") == datasets
     named_datasets = {
         SEMDATA["SEM_cement_batch2/77600-23-001/77600-23-001_5kV_400x_m001"],
         SEMDATA["SEM_cement_batch2/77600-23-001"],
@@ -449,32 +449,30 @@ def test_datadoc():
     }
     assert not named_datasets.difference(datasets)
 
-    assert set(
-        search_iris(ts, criterias={"creator.name": "Sigurd Wenner"})
-    ) == {
+    assert set(search(ts, criterias={"creator.name": "Sigurd Wenner"})) == {
         SEMDATA["SEM_cement_batch2/77600-23-001/77600-23-001_5kV_400x_m001"],
         SEMDATA["SEM_cement_batch2/77600-23-001"],
         SEMDATA["SEM_cement_batch2"],
     }
-    assert set(search_iris(ts, type=CHAMEO.Sample)) == {
+    assert set(search(ts, type=CHAMEO.Sample)) == {
         SAMPLE["SEM_cement_batch2/77600-23-001"],
     }
 
     with pytest.raises(NoSuchTypeError):
-        search_iris(ts, type="invalid-type")
+        search(ts, type="invalid-type")
 
     # Find all individuals that has "SEM images"in the title
-    assert set(search_iris(ts, regex={"dcterms:title": "SEM images"})) == {
+    assert set(search(ts, regex={"dcterms:title": "SEM images"})) == {
         SEMDATA.SEM_cement_batch2,
         SAMPLE["SEM_cement_batch2/77600-23-001"],
     }
-    assert set(search_iris(ts, regex={"dcterms:title": "SEM i[^ ]*s"})) == {
+    assert set(search(ts, regex={"dcterms:title": "SEM i[^ ]*s"})) == {
         SEMDATA.SEM_cement_batch2,
         SAMPLE["SEM_cement_batch2/77600-23-001"],
     }
 
     # Get individual with given IRI
-    assert search_iris(ts, criterias={"@id": SEMDATA.SEM_cement_batch2}) == [
+    assert search(ts, criterias={"@id": SEMDATA.SEM_cement_batch2}) == [
         SEMDATA.SEM_cement_batch2,
     ]
 

--- a/tripper/datadoc/__init__.py
+++ b/tripper/datadoc/__init__.py
@@ -3,7 +3,9 @@
 from .context import Context, get_context
 from .dataaccess import load, save
 from .dataset import (
+    acquire,
     delete,
+    delete_iri,
     get_jsonld_context,
     get_partial_pipeline,
     get_prefixes,
@@ -11,7 +13,9 @@ from .dataset import (
     read_datadoc,
     save_datadoc,
     save_dict,
+    search,
     search_iris,
+    store,
     told,
     validate,
 )

--- a/tripper/datadoc/clitool.py
+++ b/tripper/datadoc/clitool.py
@@ -16,7 +16,7 @@ from tripper.datadoc import (
     get_jsonld_context,
     load,
     save_datadoc,
-    search_iris,
+    search,
     store,
 )
 
@@ -74,7 +74,7 @@ def subcommand_find(ts, args):
                 key, value = crit.split("=", 1)
                 criterias[key] = value
 
-    iris = search_iris(ts, type=args.type, criterias=criterias, regex=regex)
+    iris = search(ts, type=args.type, criterias=criterias, regex=regex)
 
     # Infer format
     if args.format:

--- a/tripper/datadoc/clitool.py
+++ b/tripper/datadoc/clitool.py
@@ -11,13 +11,13 @@ from pathlib import Path
 from tripper import Session, Triplestore
 from tripper.datadoc import (
     TableDoc,
+    acquire,
     delete,
     get_jsonld_context,
     load,
-    load_dict,
     save_datadoc,
-    save_dict,
     search_iris,
+    store,
 )
 
 
@@ -89,17 +89,17 @@ def subcommand_find(ts, args):
         s = "\n".join(iris)
     elif fmt == "json":
         s = json.dumps(
-            [load_dict(ts, iri) for iri in iris if not iri.startswith("_:")],
+            [acquire(ts, iri) for iri in iris if not iri.startswith("_:")],
             indent=2,
         )
     elif fmt in ("turtle", "ttl"):
         ts2 = Triplestore("rdflib")
         for iri in iris:
-            d = load_dict(ts, iri)
-            save_dict(ts2, d)
+            d = acquire(ts, iri)
+            store(ts2, d)
         s = ts2.serialize()
     elif fmt == "csv":
-        dicts = [load_dict(ts, iri) for iri in iris]
+        dicts = [acquire(ts, iri) for iri in iris]
         td = TableDoc.fromdicts(dicts)
         with io.StringIO() as f:
             td.write_csv(f, prefixes=ts.namespaces)

--- a/tripper/datadoc/dataaccess.py
+++ b/tripper/datadoc/dataaccess.py
@@ -35,7 +35,7 @@ def save(
     generator: "Optional[str]" = None,
     prefixes: "Optional[dict]" = None,
     use_sparql: "Optional[bool]" = None,
-    method: str = "retain",
+    method: str = "raise",
 ) -> str:
     """Saves data to a dataresource and document it in the triplestore.
 
@@ -66,11 +66,15 @@ def save(
         use_sparql: Whether to access the triplestore with SPARQL.
             Defaults to `ts.prefer_sparql`.
         method: How to handle the case where `ts` already contains a document
-            with the same id as `data`. Possible values are:
+            with the same id as `source`. Possible values are:
             - "overwrite": Remove existing documentation before storing.
-            - "retain": Raise an `IRIAlExistsError` if the IRI of `source`
+            - "raise": Raise an `IRIExistsError` if the IRI of `source`
               already exits in the triplestore (default).
-            - "merge": Merge `source` with existing documentation.
+            - "merge": Merge `source` with existing documentation. This will
+              duplicate non-literal properties with no explicit `@id`. If this
+              is unwanted, merge manually and use "overwrite".
+            - "ignore": If the IRI of `source` already exists, do nothing but
+              issueing an `IRIExistsWarning`.
 
     Returns:
         IRI of the dataset.

--- a/tripper/datadoc/dataaccess.py
+++ b/tripper/datadoc/dataaccess.py
@@ -68,8 +68,8 @@ def save(
         method: How to handle the case where `ts` already contains a document
             with the same id as `data`. Possible values are:
             - "overwrite": Remove existing documentation before storing.
-            - "retain": Raise an `IRIAlreadyExistsError` if the IRI of `source`
-              already exits in the triplestore.
+            - "retain": Raise an `IRIAlExistsError` if the IRI of `source`
+              already exits in the triplestore (default).
             - "merge": Merge `source` with existing documentation.
 
     Returns:

--- a/tripper/datadoc/dataaccess.py
+++ b/tripper/datadoc/dataaccess.py
@@ -19,9 +19,7 @@ from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 
 from tripper import DCAT, Triplestore
-from tripper.datadoc.dataset import add, get
-from tripper.datadoc.dataset import load as load_doc
-from tripper.datadoc.dataset import store
+from tripper.datadoc.dataset import acquire, add, get, store
 from tripper.utils import AttrDict
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -94,7 +92,7 @@ def save(
         dataset = AttrDict({"@id": newiri, "@type": typeiri})
         save_dataset = True
     elif isinstance(dataset, str):
-        dset = load_doc(ts, iri=dataset, use_sparql=use_sparql)
+        dset = acquire(ts, iri=dataset, use_sparql=use_sparql)
         if dset:
             dataset = dset
         else:
@@ -121,7 +119,7 @@ def save(
             triples.append((dataset["@id"], DCAT.distribution, newiri))
             save_distribution = True
     if isinstance(distribution, str):
-        distr = load_doc(ts, iri=distribution, use_sparql=use_sparql)
+        distr = acquire(ts, iri=distribution, use_sparql=use_sparql)
         if distr:
             distribution = distr
         else:
@@ -235,7 +233,7 @@ def load(
     import dlite
     from dlite.protocol import Protocol
 
-    dct = load_doc(ts, iri=iri, use_sparql=use_sparql)
+    dct = acquire(ts, iri=iri, use_sparql=use_sparql)
     if DCAT.Dataset not in get(dct, "@type"):
         raise TypeError(
             f"expected IRI '{iri}' to be a dataset, but got: "

--- a/tripper/datadoc/dataset.py
+++ b/tripper/datadoc/dataset.py
@@ -1323,7 +1323,7 @@ def search_iris(
 ) -> "List[str]":
     """This function is deprecated. Use search() instead."""
     warnings.warn(
-        "tripper.datadoc.save_dict() is deprecated. "
+        "tripper.datadoc.search_iris() is deprecated. "
         "Please use tripper.datadoc.search() instead.",
         category=DeprecationWarning,
         stacklevel=2,

--- a/tripper/datadoc/dataset.py
+++ b/tripper/datadoc/dataset.py
@@ -388,7 +388,7 @@ def store(
             else:
                 raise ValueError(
                     f"Invalid storage method: '{method}'. "
-                    "Should be one of: 'overwrite', 'retain' or 'merge'"
+                    "Should be one of: 'overwrite', 'raise', 'ignore' or 'merge'"
                 )
 
     context.sync_prefixes(ts)

--- a/tripper/datadoc/dataset.py
+++ b/tripper/datadoc/dataset.py
@@ -1102,7 +1102,7 @@ def get_partial_pipeline(
 
 
 def delete_iri(ts: Triplestore, iri: str) -> None:
-    """Remove `iri` from triplestore using SPARQL."""
+    """Delete `iri` from triplestore using SPARQL."""
     subj = iri if iri.startswith("_:") else f"<{ts.expand_iri(iri)}>"
     query = f"""
     # Some backends requires the prefix to be defined...

--- a/tripper/datadoc/dataset.py
+++ b/tripper/datadoc/dataset.py
@@ -340,9 +340,11 @@ def store(
         method: How to handle the case where `ts` already contains a document
             with the same id as `source`. Possible values are:
             - "overwrite": Remove existing documentation before storing.
-            - "retain": Raise an `IRIAlreadyExistsError` if the IRI of `source`
-              already exits in the triplestore.
-            - "merge": Merge `source` with existing documentation.
+            - "retain": Raise an `IRIExistsError` if the IRI of `source`
+              already exits in the triplestore (default).
+            - "merge": Merge `source` with existing documentation. This will
+              duplicate non-literal properties with no explicit `@id`. If this
+              is unwanted, merge manually and use "overwrite".
 
     Returns:
         A copy of `source` updated to valid JSON-LD.

--- a/tripper/datadoc/dataset.py
+++ b/tripper/datadoc/dataset.py
@@ -424,6 +424,7 @@ def save_dict(
     prefixes: "Optional[dict]" = None,
     method: str = "merge",
 ) -> dict:
+    """This function is deprecated. Use store() instead."""
     # pylint: disable=missing-function-docstring
     warnings.warn(
         "tripper.datadoc.save_dict() is deprecated. "
@@ -440,9 +441,6 @@ def save_dict(
         prefixes=prefixes,
         method=method,
     )
-
-
-save_dict.__doc__ = store.__doc__
 
 
 def save_extra_content(ts: Triplestore, source: dict) -> None:
@@ -554,7 +552,7 @@ def acquire(
 def load_dict(
     ts: Triplestore, iri: str, use_sparql: "Optional[bool]" = None
 ) -> dict:
-    # pylint: disable=missing-function-docstring
+    """This function is deprecated. Use acquire() instead."""
     warnings.warn(
         "tripper.datadoc.load_dict() is deprecated. "
         "Please use tripper.datadoc.acquire() instead.",
@@ -562,9 +560,6 @@ def load_dict(
         stacklevel=2,
     )
     return acquire(ts=ts, iri=iri, use_sparql=use_sparql)
-
-
-load_dict.__doc__ = acquire.__doc__
 
 
 def _load_triples(ts: Triplestore, iri: str) -> dict:
@@ -1326,10 +1321,10 @@ def search_iris(
     keywords: "Optional[Keywords]" = None,
     skipblanks: "bool" = True,
 ) -> "List[str]":
-    # pylint: disable=missing-function-docstring
+    """This function is deprecated. Use search() instead."""
     warnings.warn(
         "tripper.datadoc.save_dict() is deprecated. "
-        "Please use tripper.datadoc.store() instead.",
+        "Please use tripper.datadoc.search() instead.",
         category=DeprecationWarning,
         stacklevel=2,
     )
@@ -1342,9 +1337,6 @@ def search_iris(
         keywords=keywords,
         skipblanks=skipblanks,
     )
-
-
-search_iris.__doc__ = search.__doc__
 
 
 def delete(

--- a/tripper/datadoc/dataset.py
+++ b/tripper/datadoc/dataset.py
@@ -1253,7 +1253,7 @@ def search(
 
         List IRIs of all resources with John Doe as `contactPoint`:
 
-            search(ts, criteria={"contactPoint.hasName": "John Doe"})
+            search(ts, criterias={"contactPoint.hasName": "John Doe"})
 
         List IRIs of all samples:
 
@@ -1265,7 +1265,7 @@ def search(
             search(
                 ts,
                 type=DCAT.Dataset,
-                criteria={
+                criterias={
                     "contactPoint.hasName": "John Doe",
                     "fromSample": SAMPLE.batch2/sample3,
                 },

--- a/tripper/datadoc/errors.py
+++ b/tripper/datadoc/errors.py
@@ -27,6 +27,10 @@ class InvalidContextError(TripperError):
     """Context is invalid."""
 
 
+class IRIExistsError(TripperError):
+    """The IRI already exists in the triplestore."""
+
+
 class UnknownKeywordWarning(TripperWarning):
     """Unknown keyword in data documentation."""
 

--- a/tripper/datadoc/errors.py
+++ b/tripper/datadoc/errors.py
@@ -37,3 +37,7 @@ class UnknownKeywordWarning(TripperWarning):
 
 class MissingKeywordsClassWarning(UnknownKeywordWarning):
     """A class is referred to that is not defined in a keywords file."""
+
+
+class IRIExistsWarning(TripperWarning):
+    """The IRI already exists in the triplestore."""

--- a/tripper/datadoc/keywords.py
+++ b/tripper/datadoc/keywords.py
@@ -347,6 +347,18 @@ class Keywords:
             "- **Definition**: The definition of the keyword.",
             "- **Usage note**: Notes about how to use the keyword.",
             "",
+            "## Special keywords (from JSON-LD)",
+            "See the [JSON-LD specification] for more details.",
+            "",
+            # pylint: disable=line-too-long
+            "| Keyword    | Range         | Conformance | Definition                                                   | Usage note |",
+            "|------------|---------------|-------------|--------------------------------------------------------------|------------|",
+            "| [@id]      | IRI           | mandatory   | IRI identifying the resource to document.                    |            |",
+            "| [@type]    | IRI           | recommended | Ontological class defining the class of a node.              |            |",
+            "| [@context] | dict&#124list | optional    | Context defining namespace prefixes and additional keywords. |            |",
+            "| [@base]    | list          | optional    | Base IRI against which relative IRIs are resolved.           |            |",
+            "| [@graph]   | list          | optional    | Used for documenting multiple resources.                     |            |",
+            "",
         ]
         order = {"mandatory": 1, "recommended": 2, "optional": 3}
         refs = []
@@ -406,6 +418,15 @@ class Keywords:
             out.append("")
 
         # References
+        extra_refs = [
+            # pylint: disable=line-too-long
+            "[@id]: https://www.w3.org/TR/json-ld11/#syntax-tokens-and-keywords",
+            "[@type]: https://www.w3.org/TR/json-ld11/#syntax-tokens-and-keywords",
+            "[@context]: https://www.w3.org/TR/json-ld11/#syntax-tokens-and-keywords",
+            "[@base]: https://www.w3.org/TR/json-ld11/#syntax-tokens-and-keywords",
+            "[@graph]: https://www.w3.org/TR/json-ld11/#syntax-tokens-and-keywords",
+        ]
+        refs.extend(extra_refs)
         out.append("")
         out.append("")
         out.append("")
@@ -433,13 +454,12 @@ class Keywords:
         out.extend(self._to_table(["Prefix", "Namespace"], rows))
         out.append("")
         out.append("")
-        out.append(
-            "[default JSON-LD context]: https://raw.githubuser"
-            "content.com/EMMC-ASBL/tripper/refs/heads/master/"
-            "tripper/context/0.2/context.json"
-        )
-        out.append(
-            "[User-defined prefixes]: customisation.md/#user-defined-prefixes"
+        out.extend(
+            [
+                # pylint: disable=line-too-long
+                "[default JSON-LD context]: https://raw.githubusercontent.com/EMMC-ASBL/tripper/refs/heads/master/tripper/context/0.3/context.json",
+                "[User-defined prefixes]: customisation.md/#user-defined-prefixes",
+            ]
         )
         with open(outfile, "wt", encoding="utf-8") as f:
             f.write("\n".join(out) + "\n")

--- a/tripper/datadoc/keywords.py
+++ b/tripper/datadoc/keywords.py
@@ -351,13 +351,14 @@ class Keywords:
             "See the [JSON-LD specification] for more details.",
             "",
             # pylint: disable=line-too-long
-            "| Keyword    | Range         | Conformance | Definition                                                   | Usage note |",
-            "|------------|---------------|-------------|--------------------------------------------------------------|------------|",
-            "| [@id]      | IRI           | mandatory   | IRI identifying the resource to document.                    |            |",
-            "| [@type]    | IRI           | recommended | Ontological class defining the class of a node.              |            |",
-            "| [@context] | dict&#124list | optional    | Context defining namespace prefixes and additional keywords. |            |",
-            "| [@base]    | list          | optional    | Base IRI against which relative IRIs are resolved.           |            |",
-            "| [@graph]   | list          | optional    | Used for documenting multiple resources.                     |            |",
+            "| Keyword    | Range         | Conformance | Definition                                                              | Usage note |",
+            "|------------|---------------|-------------|-------------------------------------------------------------------------|------------|",
+            "| [@id]      | IRI           | mandatory   | IRI identifying the resource to document.                               |            |",
+            "| [@type]    | IRI           | recommended | Ontological class defining the class of a node.                         |            |",
+            "| [@context] | dict&#124list | optional    | Context defining namespace prefixes and additional keywords.            |            |",
+            "| [@base]    | namespace     | optional    | Base IRI against which relative IRIs are resolved.                      |            |",
+            "| [@vocab]   | namespace     | optional    | Used to expand properties and values in @type with a common prefix IRI. |            |",
+            "| [@graph]   | list          | optional    | Used for documenting multiple resources.                                |            |",
             "",
         ]
         order = {"mandatory": 1, "recommended": 2, "optional": 3}
@@ -424,6 +425,7 @@ class Keywords:
             "[@type]: https://www.w3.org/TR/json-ld11/#syntax-tokens-and-keywords",
             "[@context]: https://www.w3.org/TR/json-ld11/#syntax-tokens-and-keywords",
             "[@base]: https://www.w3.org/TR/json-ld11/#syntax-tokens-and-keywords",
+            "[@vocab]: https://www.w3.org/TR/json-ld11/#syntax-tokens-and-keywords",
             "[@graph]: https://www.w3.org/TR/json-ld11/#syntax-tokens-and-keywords",
         ]
         refs.extend(extra_refs)

--- a/tripper/datadoc/tabledoc.py
+++ b/tripper/datadoc/tabledoc.py
@@ -11,7 +11,7 @@ from tripper import Triplestore
 from tripper.datadoc.context import Context
 from tripper.datadoc.dataset import (
     addnested,
-    save_dict,
+    store,
     told,
 )
 from tripper.utils import AttrDict, openfile
@@ -86,7 +86,7 @@ class TableDoc:
         for prefix, ns in self.context.get_prefixes().items():
             ts.bind(prefix, ns)
 
-        save_dict(ts, self.asdicts(), type=self.type, context=self.context)
+        store(ts, self.asdicts(), type=self.type, context=self.context)
 
     def asdicts(self) -> "List[dict]":
         """Return the table as a list of dicts."""

--- a/tripper/utils.py
+++ b/tripper/utils.py
@@ -732,7 +732,7 @@ def check_service_availability(url: str, timeout=5, interval=1) -> bool:
             response = requests.get(url, timeout=timeout)
             if response.status_code == 200:
                 return True
-        except requests.exceptions.RequestException:
+        except (requests.exceptions.RequestException, IOError):
             pass
 
         if time.time() - start_time >= timeout:

--- a/tripper/utils.py
+++ b/tripper/utils.py
@@ -732,7 +732,7 @@ def check_service_availability(url: str, timeout=5, interval=1) -> bool:
             response = requests.get(url, timeout=timeout)
             if response.status_code == 200:
                 return True
-        except (requests.exceptions.RequestException, IOError):
+        except requests.exceptions.RequestException:
             pass
 
         if time.time() - start_time >= timeout:


### PR DESCRIPTION
# Description
Added a `method` argument to `dataset.store()` that allows the user to control whether an existing IRI should be overwritten or merged. The default is to raise an exception.

Other changes:
* Renamed some functions with awkward names:
  - `save_dict() -> store()`
  - `load_dict() -> acquire()`
  - `search_iris() -> search()`
  
  Using old function names will work, but trigger a deprecation warning.
* Cleaned up documentation.

## Type of change
- [x] Bug fix and code cleanup
- [x] New feature
- [x] Documentation update
- [x] Testing


## Checklist for the reviewer
This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
- [ ] Is the code properly tested?
