### PR TITLE
Build documentation with Python 3.12

### DIFF
--- a/.github/workflows/ci_cd_updated_main.yml
+++ b/.github/workflows/ci_cd_updated_main.yml
@@ -24,7 +24,7 @@ jobs:
       update_python_api_ref: true
       package_dirs: tripper
       update_docs_landing_page: true
-      python_version: "3.13"
+      python_version: "3.12"
       doc_extras: "[docs]"
       changelog_exclude_labels: "skip_changelog,duplicate,question,invalid,wontfix"
       docs_framework: mkdocs


### PR DESCRIPTION
# Description
Downgrade from Python 3.13 to 3.12 when building docs.

We can't use Python 3.13, since the ontopy backend depends on EMMOntoPy and EMMOntoPy doesn't support Python 3.13.

## Type of change
- [x] Bug fix and code cleanup
- [ ] New feature
- [ ] Documentation update
- [ ] Testing


## Checklist for the reviewer
This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
- [ ] Is the code properly tested?
