### PR TITLE
Fix linting warnings for bound prefixes

### DIFF
--- a/tripper/triplestore.py
+++ b/tripper/triplestore.py
@@ -22,7 +22,7 @@ import subprocess  # nosec
 import sys
 import warnings
 from collections.abc import Sequence
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, overload
 
 from tripper.errors import (
     ArgumentTypeError,
@@ -451,7 +451,23 @@ class Triplestore:
         self._check_method("update")
         return self.backend.update(update_object=update_object, **kwargs)
 
-    def bind(  # pylint: disable=inconsistent-return-statements
+    @overload
+    def bind(
+        self,
+        prefix: str,
+        namespace: "Union[str, Namespace, Triplestore]",
+        **kwargs,
+    ) -> "Namespace": ...
+
+    @overload
+    def bind(
+        self,
+        prefix: str,
+        namespace: None,
+        **kwargs,
+    ) -> None: ...
+
+    def bind(
         self,
         prefix: str,
         namespace: "Union[str, Namespace, Triplestore, None]" = "",


### PR DESCRIPTION
# Description
When binding a prefix, many warnings appear in linted code to the prefix, as example below.

```python
ts = Triplestore(backend="rdflib")
EX = ts.bind("ex", "http://organisation.org/")
AEC = ts.bind("aec", "http://example.org/aec#")

ts.add((EX.Orgname_Ltd, RDF.type, AEC.Organisation),
#          ^^^^^^^^^^^                ^^^^^^^^^^^^
# "Orgname_Ltd" is not a known attribute of "None" Pylance(reportOptionalMemberAccess)

ts.add((EX["Orgname2_Ltd"], ..., ...),
#       ^^
# Object of type "None" is not subscriptable Pylance(reportOptionalSubscript)
# ...
```

The added overloads fixes these uses.

## Type of change
- [x] Bug fix and code cleanup
- [ ] New feature
- [ ] Documentation update
- [ ] Testing


## Checklist for the reviewer
This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
- [ ] Is the code properly tested?
