### PR TITLE
Added substitute_query() function

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -525,6 +525,39 @@ def test_prefix_iri():
         prefix_iri("xxx", prefixes, require_prefixed=True)
 
 
+def test_substitute_query():
+    """Test substitute_query()."""
+    from tripper import FOAF
+    from tripper.utils import substitute_query
+
+    assert (
+        substitute_query(
+            query="SELECT ?s WHERE { ?s $name $obj }",
+            iris={"name": "foaf:name"},
+            literals={"obj": "John Dow"},
+            prefixes={"foaf": str(FOAF)},
+        )
+        == f'SELECT ?s WHERE {{ ?s <{FOAF.name}> "John Dow" }}'
+    )
+
+    assert (
+        substitute_query(
+            query="SELECT ?s WHERE { ?s $name $obj }",
+            iris={
+                "name": (
+                    'http://xmlns.com/foaf/0.1/name> "x" . '
+                    "<something nasty> <"
+                )
+            },
+            literals={"obj": 'John Dow" . <something nasty> "'},
+        )
+    ) == (
+        "SELECT ?s WHERE { ?s <http://xmlns.com/foaf/0.1/name"
+        "%3E%20%22x%22%20.%20%3Csomething%20nasty%3E%20%3C>"
+        r' "John Dow\" . <something nasty> \"" }'
+    )
+
+
 def test_get_entry_points():
     """Test get_entry_points()"""
     from tripper.utils import get_entry_points

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -557,6 +557,11 @@ def test_substitute_query():
         r' "John Dow\" . <something nasty> \"" }'
     )
 
+    assert substitute_query("$x $y", iris={"x": "X"}) == "<X> $y"
+    assert substitute_query("$x", iris={"x": "X"}, iriquote="[]") == "[X]"
+    assert substitute_query("$x", iris={"x": "X"}, iriquote=" ") == " X "
+    assert substitute_query("$x", iris={"x": "X"}, iriquote=None) == "X"
+
 
 def test_get_entry_points():
     """Test get_entry_points()"""

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -562,6 +562,12 @@ def test_substitute_query():
     assert substitute_query("$x", iris={"x": "X"}, iriquote=" ") == " X "
     assert substitute_query("$x", iris={"x": "X"}, iriquote=None) == "X"
 
+    with pytest.raises(ValueError):
+        substitute_query("$x", iris={"x": "X"}, iriquote="xxx")
+
+    with pytest.warns(UserWarning):
+        substitute_query("$x", iris={"x": "X"}, iriquote="--")
+
 
 def test_get_entry_points():
     """Test get_entry_points()"""

--- a/tripper/triplestore.py
+++ b/tripper/triplestore.py
@@ -510,7 +510,7 @@ class Triplestore:
         new_query = substitute_query(
             query, iris=iris, literals=literals, prefixes=self.namespaces
         )
-        return self.backend.update(update_object=new_query, **kwargs)
+        return self.backend.update(new_query, **kwargs)
 
     @overload
     def bind(

--- a/tripper/triplestore.py
+++ b/tripper/triplestore.py
@@ -54,6 +54,7 @@ from tripper.utils import (
     infer_iri,
     prefix_iri,
     split_iri,
+    substitute_query,
 )
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -412,11 +413,32 @@ class Triplestore:
             ts.bind(prefix, iri)
         return ts.serialize(destination=destination, format=format, **kwargs)
 
-    def query(self, query_object, **kwargs) -> "Any":
+    def query(
+        self,
+        query: str,
+        iris: "Optional[dict]" = None,
+        literals: "Optional[dict]" = None,
+        **kwargs,
+    ) -> "Any":
         """SPARQL query.
 
+        The `query` argument may contain variables for IRIs and literals,
+        to be substituted using the `iris` and `literals` arguments. These
+        variables are prefixed `$`. This makes them easy to distinguish from
+        query variables, that are typically prefixed with `?`.
+
+        The query substitutions may be useful when the query is constructed
+        from user input, since they are properly escaped and will be inserted
+        in the query as a single token.  This may prevent sparql injection
+        attacks.
+
         Arguments:
-            query_object: String with the SPARQL query.
+            query: String with the SPARQL query.
+            iris: Dict used for query substitutions that maps IRI variables
+                to IRIs. The IRIs may be provided as fully expanded or
+                prefixed with a prefix registered in the triplestore namespace.
+            literals: Dict used for query substitutions that maps literal
+                variables to literals.
             kwargs: Keyword arguments passed to the backend query() method.
 
         Returns:
@@ -432,24 +454,63 @@ class Triplestore:
 
             Not all backends may support all types of queries.
 
+        Examples:
+            Query for everyone with the name "John Dow":
+
+            >>> from tripper import FOAF, Literal, Triplestore
+            >>> ts = Triplestore(backend="rdflib")
+            >>> ts.bind("foaf", FOAF)
+            Namespace('http://xmlns.com/foaf/0.1/')
+
+            >>> ts.add_triples([
+            ...     (":john", FOAF.name, Literal("John Dow")),
+            ...     (":jack", FOAF.name, Literal("Jack Hudson")),
+            ... ])
+            >>> ts.query(
+            ...     "SELECT ?s WHERE { ?s $name $obj .}",
+            ...     iris={"name": "foaf:name"},
+            ...     literals={"obj": "John Dow"},
+            ... )
+            [(':john',)]
+
         """
         self._check_method("query")
-        return self.backend.query(query_object=query_object, **kwargs)
+        new_query = substitute_query(
+            query, iris=iris, literals=literals, prefixes=self.namespaces
+        )
+        return self.backend.query(new_query, **kwargs)
 
-    def update(self, update_object, **kwargs) -> None:
+    def update(
+        self,
+        query: str,
+        iris: "Optional[dict]" = None,
+        literals: "Optional[dict]" = None,
+        **kwargs,
+    ) -> None:
         """Update triplestore with SPARQL.
 
         Arguments:
-            update_object: String with the SPARQL query.
+            query: String with the SPARQL query.
+            iris: Dict used for query substitutions that maps IRI variables
+                to IRIs. The IRIs may be provided as fully expanded or
+                prefixed with a prefix registered in the triplestore namespace.
+            literals: Dict used for query substitutions that maps literal
+                variables to literals.
             kwargs: Keyword arguments passed to the backend update() method.
 
         Note:
+            See `query()` for how to the query substitution arguments `iris`
+            and `literals`.
+
             This method is intended for INSERT and DELETE queries. Use
             the query() method for SELECT, ASK, CONSTRUCT and DESCRIBE queries.
 
         """
         self._check_method("update")
-        return self.backend.update(update_object=update_object, **kwargs)
+        new_query = substitute_query(
+            query, iris=iris, literals=literals, prefixes=self.namespaces
+        )
+        return self.backend.update(update_object=new_query, **kwargs)
 
     @overload
     def bind(


### PR DESCRIPTION
# Description
Added a substitute_query() function to make it easier to build safe SPARQL interfaces.

## Type of change
- [ ] Bug fix and code cleanup
- [x] New feature
- [ ] Documentation update
- [ ] Testing


## Checklist for the reviewer
This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
- [ ] Is the code properly tested?
