### PR TITLE
Added available() method and `check_url` to argument to Triplestore

### DIFF
--- a/docs/developers.md
+++ b/docs/developers.md
@@ -4,12 +4,19 @@
 
 See [interface.py], which defines the interface of a backend and may serve as a template for creating new backends.
 
-### Developing the sparqlwrapper
 
+## Setting up local GraphDB and Fuseki services for testing
 Tripper comes with an inbuilt backend to the SPARQLWrapper. In order
 to test this properly a real triplestore is needed. This is not done in the
-automatic workflows on github. However, a local graphDB can be setup as described below and tested with test_sparqlwrapper_graphdb.py.
+automatic workflows on github. However, local graphDB and Fuseki services
+can be setup as described below and tested with
+`tests/backends/test_sparqlwrapper_graphdb_fuseki.py`.
 
+The backend configurations corresponding to the local GraphDB and Fuseki services
+can be found in `[tests/input/session.yaml]`.
+
+
+### Setting up GraphDB service
 To create the local instance of graphdb:
 ```bash
 docker pull ontotext/graphdb:10.8.3 # latest tag 17.02.2025
@@ -30,6 +37,7 @@ You can now run the test test_sparqlwrapper_graphdb_fuseki.py with graphdb.
 Note that if the graphdb instance is not found the test will just be skipped.
 
 
+### Setting up Fuseki service
 Similarly a jena-fuseki instance can be tested locally as follows:
 
 ```bash
@@ -37,7 +45,7 @@ docker pull stain/jena-fuseki
 docker run -d --name fuseki -p 3030:3030 -e ADMIN_PASSWORD=admin0 -e=FUSEKI_DATASET_1=test_repo stain/jena-fuseki
 ```
 
-You can now run the test test_sparqlwrapper_graphdb_fuseki.py with fuseki.
+You can now run the test `test_sparqlwrapper_graphdb_fuseki.py` with fuseki.
 
 Note that if the fuseki instance is not found the test will just be skipped.
 
@@ -75,3 +83,4 @@ Then open http://127.0.0.1:8000/tripper/ in your browser.
 
 [interface.py]: https://github.com/EMMC-ASBL/tripper/blob/master/tripper/interface.py
 [mkdocs]: https://www.mkdocs.org/
+[tests/input/session.yaml]: https://github.com/EMMC-ASBL/tripper/blob/master/tests/input/session.yaml)

--- a/docs/session.md
+++ b/docs/session.md
@@ -11,18 +11,28 @@ The default location of this configuration file depends on the system:
 - Windows: `$HOME/AppData/Local/tripper/Config/session.yaml`
 - Darwin: `$HOME/Library/Config/tripper/session.yaml`
 
-Add some default
+The schema of the YAML file is simple.
+A session should have a name that identifies it and should be followed by keyword arguments accepted by the `Triplestore` constructor.
+
+Here is an example of a possible session file:
 
 ```
+---
+
+RdflibTest:
+  backend: rdflib
+
 GraphDBTest:
   backend: sparqlwrapper
   base_iri: http://localhost:7200/repositories/test_repo
   update_iri: http://localhost:7200/repositories/test_repo/statements
+  check_url: http://localhost:7200/repositories
 
 FusekiTest:
   backend: sparqlwrapper
   base_iri: http://localhost:3030/test_repo
   update_iri: http://localhost:3030/test_repo/update
+  check_url: http://localhost:3030
   username: admin
   password: admin0
 
@@ -30,15 +40,18 @@ MyKB:
   backend: sparqlwrapper
   base_iri: https://graphdb.myproject.eu/repositories/test_repo
   update_iri: https://graphdb.myproject.eu/repositories/test_repo/statements
+  check_url: https://graphdb.myproject.eu/repositories
   username: myname
   password: KEYRING
 ```
 
-The two first entries correspond to the GraphDB and Fuseki services
-that can be started with docker as described in the [developers]
-section.
+The first entry is an in-memory rdflib backend.
 
-The third entry is just a dummy example, showing how to use [keyring].
+The second and third entries correspond to GraphDB and Fuseki services,
+respectively.
+These can be started with docker as described in the [developers] section.
+
+The fourth entry is just a dummy example, showing how to use [keyring].
 
 Each entry starts with the name identifying the configured triplestore.
 The keywords following it, correspond to the keyword arguments passed to the

--- a/tests/input/session.yaml
+++ b/tests/input/session.yaml
@@ -5,6 +5,7 @@ FusekiTest:
   backend: sparqlwrapper
   base_iri: http://localhost:3030/test_repo
   update_iri: http://localhost:3030/test_repo/update
+  check_url: http://localhost:3030
   username: admin
   password: admin0
 
@@ -12,3 +13,4 @@ GraphDBTest:
   backend: sparqlwrapper
   base_iri: http://localhost:7200/repositories/test_repo
   update_iri: http://localhost:7200/repositories/test_repo/statements
+  check_url: http://localhost:7200/repositories

--- a/tests/input/session.yaml
+++ b/tests/input/session.yaml
@@ -1,3 +1,9 @@
+# Default sessions used for testing
+#
+# See https://emmc-asbl.github.io/tripper/latest/developers/ for how to set
+# up local instances of GraphDB and Fuseki corresponding to the settings below.
+
+
 RdflibTest:
   backend: rdflib
 


### PR DESCRIPTION
# Description
Integrated checking if a backend service is available to the standard Triplestore API, by adding the available() method and `check_url` to argument to the Triplestore class.

The `check_url` can now be configured together with other parameters in the session. 

## Type of change
- [ ] Bug fix and code cleanup
- [x] New feature
- [ ] Documentation update
- [ ] Testing


## Checklist for the reviewer
This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
- [ ] Is the code properly tested?
