### PR TITLE
Fixed some issues with sparql backend

### DIFF
--- a/tripper/backends/sparqlwrapper.py
+++ b/tripper/backends/sparqlwrapper.py
@@ -94,7 +94,7 @@ class SparqlwrapperStrategy:
 
         if query_type == "ASK":
             self.sparql.setReturnFormat(JSON)
-            self.sparql.setMethod(POST)
+            self.sparql.setMethod(GET)
             self.sparql.setQuery(query_object)
             result = self.sparql.queryAndConvert()
             value = result["boolean"]
@@ -102,7 +102,7 @@ class SparqlwrapperStrategy:
 
         if query_type == "CONSTRUCT":
             self.sparql.setReturnFormat(TURTLE)
-            self.sparql.setMethod(POST)
+            self.sparql.setMethod(GET)
             self.sparql.setQuery(query_object)
             results = self.sparql.queryAndConvert()
             graph = Graph()
@@ -111,7 +111,7 @@ class SparqlwrapperStrategy:
 
         if query_type == "DESCRIBE":
             self.sparql.setReturnFormat(TURTLE)
-            self.sparql.setMethod(POST)
+            self.sparql.setMethod(GET)
             self.sparql.setQuery(query_object)
             results = self.sparql.queryAndConvert()
             graph = Graph()
@@ -120,7 +120,7 @@ class SparqlwrapperStrategy:
 
         if query_type == "SELECT":
             self.sparql.setReturnFormat(JSON)
-            self.sparql.setMethod(POST)
+            self.sparql.setMethod(GET)
             self.sparql.setQuery(query_object)
             ret = self.sparql.queryAndConvert()
             bindings = ret["results"]["bindings"]
@@ -173,6 +173,7 @@ class SparqlwrapperStrategy:
             raise NotImplementedError(
                 f"Update query type '{query_type}' not implemented."
             )
+        self.sparql.setReturnFormat(TURTLE)
         self.sparql.setMethod(POST)
         self.sparql.setQuery(update_object)
         self.sparql.query()


### PR DESCRIPTION
# Description
Found a few issues in the sparqlwrapper backend when testing SELECT and UPDATE sparql queries against the MatCHMaker GraphDB instance. 

Not sure why these issues haven't been detected before. SELECT and UPDATE queries are well tested in the test_sparqlwrapper_graphdb_fusiki.py. Maybe it depends on the version of the GraphDB instance?

## Type of change
- [x] Bug fix and code cleanup
- [ ] New feature
- [ ] Documentation update
- [ ] Testing


## Checklist for the reviewer
This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
- [ ] Is the code properly tested?
