### PR TITLE
Iri in restrictions are not treated correctly when parsed into ts

### DIFF
--- a/tests/datadoc/test_context.py
+++ b/tests/datadoc/test_context.py
@@ -274,19 +274,23 @@ def test_is_class():
 
 def test_to_triplestore():
     """Test to_triplestore() method."""
-    from tripper import Namespace, Triplestore
+    # pylint: disable=too-many-locals
+    from tripper import OWL, RDF, RDFS, Namespace, Triplestore
 
     PERS = Namespace("http://example.com/person#")
     FAM = Namespace("http://example.com/family#")
     context = {
         "pers": str(PERS),
         "fam": str(FAM),
+        "owl": str(OWL),
         "son": {"@id": "fam:son", "@type": "@id"},
         "daughter": {"@id": "fam:daughter", "@type": "@id"},
-        "Son": "fam:Son",
-        "Daughter": "fam:Daughter",
+        "Son": {"@id": "fam:Son", "@type": "owl:Class"},
+        "Daughter": {"@id": "fam:Daughter", "@type": "owl:Class"},
+        "Father": {"@id": "fam:Father", "@type": "owl:Class"},
+        "father": {"@id": "fam:father", "@type": "@id"},
     }
-    ctx = get_context(context=context)
+    ctx = get_context(context=context)  # , theme="ddoc:datadoc")
 
     doc1 = {
         "@id": "pers:ada",
@@ -338,6 +342,44 @@ def test_to_triplestore():
         (PERS.cyril, FAM.daughter, PERS.ewa),
         (PERS.cyril, FAM.son, PERS.fredrik),
     }
+    ctx = get_context(context=context)
+    # OWL restriction values should be interpreted as IRIs when ingested.
+    doc4 = {
+        "@id": "fam:Son",
+        "@type": "owl:Class",
+        "subClassOf": {
+            "@type": "owl:Restriction",
+            "owl:onProperty": "fam:father",
+            "owl:someValuesFrom": "fam:Father",
+        },
+    }
+    ts4 = Triplestore("rdflib")
+    ctx.to_triplestore(ts4, doc4)
+    triples4 = set(ts4.triples())
+    print(ts4.serialize())
+    subclasses = list(ts4.triples(subject=FAM.Son, predicate=RDFS.subClassOf))
+    assert len(subclasses) == 1
+
+    restriction = subclasses[0][2]
+    assert (restriction, RDF.type, OWL.Restriction) in triples4
+    assert (restriction, OWL.onProperty, FAM.father) in triples4
+    assert (restriction, OWL.someValuesFrom, FAM.Father) in triples4
+
+    ctx = get_context(context=context)
+    # OWL restriction values should be interpreted as IRIs when ingested.
+    # should give namespaceerror
+    doc5 = {
+        "@id": "fam:Son",
+        "@type": "owl:Class",
+        "subClassOf": {
+            "@type": "owl:Restriction",
+            "owl:onProperty": "fam:father",
+            "owl:someValuesFrom": "Father",
+        },
+    }
+    ts5 = Triplestore("rdflib")
+    with pytest.raises(Exception):
+        ctx.to_triplestore(ts5, doc5)
 
 
 def test_base():

--- a/tests/datadoc/test_context.py
+++ b/tests/datadoc/test_context.py
@@ -276,6 +276,7 @@ def test_to_triplestore():
     """Test to_triplestore() method."""
     # pylint: disable=too-many-locals
     from tripper import OWL, RDF, RDFS, Namespace, Triplestore
+    from tripper.errors import NamespaceError
 
     PERS = Namespace("http://example.com/person#")
     FAM = Namespace("http://example.com/family#")
@@ -287,8 +288,6 @@ def test_to_triplestore():
         "daughter": {"@id": "fam:daughter", "@type": "@id"},
         "Son": {"@id": "fam:Son", "@type": "owl:Class"},
         "Daughter": {"@id": "fam:Daughter", "@type": "owl:Class"},
-        "Father": {"@id": "fam:Father", "@type": "owl:Class"},
-        "father": {"@id": "fam:father", "@type": "@id"},
     }
     ctx = get_context(context=context)  # , theme="ddoc:datadoc")
 
@@ -377,8 +376,9 @@ def test_to_triplestore():
             "owl:someValuesFrom": "Father",
         },
     }
+
     ts5 = Triplestore("rdflib")
-    with pytest.raises(Exception):
+    with pytest.raises(NamespaceError):
         ctx.to_triplestore(ts5, doc5)
 
 

--- a/tests/datadoc/test_context.py
+++ b/tests/datadoc/test_context.py
@@ -289,7 +289,7 @@ def test_to_triplestore():
         "Son": {"@id": "fam:Son", "@type": "owl:Class"},
         "Daughter": {"@id": "fam:Daughter", "@type": "owl:Class"},
     }
-    ctx = get_context(context=context)  # , theme="ddoc:datadoc")
+    ctx = get_context(context=context)
 
     doc1 = {
         "@id": "pers:ada",
@@ -342,7 +342,8 @@ def test_to_triplestore():
         (PERS.cyril, FAM.son, PERS.fredrik),
     }
     ctx = get_context(context=context)
-    # OWL restriction values should be interpreted as IRIs when ingested.
+    # OWL restriction values should be interpreted as IRIs
+    # when parsed into the triplestore.
     doc4 = {
         "@id": "fam:Son",
         "@type": "owl:Class",
@@ -365,8 +366,9 @@ def test_to_triplestore():
     assert (restriction, OWL.someValuesFrom, FAM.Father) in triples4
 
     ctx = get_context(context=context)
-    # OWL restriction values should be interpreted as IRIs when ingested.
-    # should give namespaceerror
+    # Same as above, but now the value of `owl:someValuesFrom`
+    # is not a valid IRI, so it should raise a NamespaceError when
+    # parsed into the triplestore.
     doc5 = {
         "@id": "fam:Son",
         "@type": "owl:Class",

--- a/tripper/context/owl-restrictions.json
+++ b/tripper/context/owl-restrictions.json
@@ -1,0 +1,13 @@
+{
+  "@context": {
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "owl": "http://www.w3.org/2002/07/owl#",
+    "subClassOf":            {"@id": "rdfs:subClassOf",       "@type": "@id"},
+    "owl:onProperty":        {"@id": "owl:onProperty",        "@type": "@id"},
+    "owl:someValuesFrom":    {"@id": "owl:someValuesFrom",    "@type": "@id"},
+    "owl:allValuesFrom":     {"@id": "owl:allValuesFrom",     "@type": "@id"},
+    "owl:hasValue":          {"@id": "owl:hasValue",          "@type": "@id"},
+    "owl:onClass":           {"@id": "owl:onClass",           "@type": "@id"},
+    "owl:onDataRange":       {"@id": "owl:onDataRange",       "@type": "@id"}
+  }
+}

--- a/tripper/datadoc/context.py
+++ b/tripper/datadoc/context.py
@@ -6,6 +6,7 @@ import json
 import os
 import re
 import warnings
+from pathlib import Path
 from typing import TYPE_CHECKING, Sequence
 
 from pyld import jsonld
@@ -533,7 +534,10 @@ class Context:
         base = baseiri if baseiri else false_prefix
 
         ts2 = Triplestore(backend="rdflib")
-        ts2.parse(data=self._todict(doc), format="json-ld", base=base)
+
+        ts2.parse(
+            data=self._todict_for_store(doc), format="json-ld", base=base
+        )
 
         # Check that no IRIs are in namespace "https://falseiri/".
         # If Force is True, issue a warning
@@ -572,6 +576,19 @@ class Context:
             if prefix not in ts.namespaces:
                 ts.bind(prefix, ns)
         return ts2
+
+    def _todict_for_store(self, doc: "Union[dict, list]") -> dict:
+        """Like _todict but adds OWL restriction coercions to the context."""
+        storedict = self._todict(doc)
+        ctx_copy = self.copy()
+        _owl_ctx = str(
+            Path(__file__).parent.parent / "context" / "owl-restrictions.json"
+        )
+        ctx_copy.add_context(_owl_ctx)
+        coercions = ctx_copy.get_context_dict()
+        for key, value in coercions.items():
+            storedict["@context"].setdefault(key, value)
+        return storedict
 
     def _todict(self, doc: "Union[dict, list]") -> dict:
         """Returns a shallow copy of doc as a dict with current


### PR DESCRIPTION
# Description
In order to achieve correct parsing a mini-context was added that is used when pushing a context to a triplestore.

## Type of change
- [ ] Bug fix and code cleanup
- [ ] New feature
- [ ] Documentation update
- [ ] Testing


## Checklist for the reviewer
This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
- [ ] Is the code properly tested?
