### PR TITLE
Allow tabledoc to have prefix in the header

### DIFF
--- a/tests/datadoc/test_tabledoc.py
+++ b/tests/datadoc/test_tabledoc.py
@@ -360,11 +360,11 @@ def test_sep():
     from tripper.datadoc import TableDoc
 
     td = TableDoc(
-        headers=["@id", "@type[?sep=,]", "title"],
+        headers=["@id", "@type[?sep=,]", "dcterms:title"],
         data=[("kb:s1", "kb:T1,kb:T2", "A title, with a comma")],
         prefixes={"kb": "http://example.com/kb#"},
     )
     (s1,) = td.asdicts()  # pylint: disable=unbalanced-tuple-unpacking
     assert s1["@id"] == "kb:s1"
     assert s1["@type"] == ["kb:T1", "kb:T2"]
-    assert s1["title"] == "A title, with a comma"
+    assert s1["dcterms:title"] == "A title, with a comma"

--- a/tripper/datadoc/context.py
+++ b/tripper/datadoc/context.py
@@ -411,11 +411,6 @@ class Context:
             self._create_caches()
         if name in self._shortnamed:
             return self._shortnamed[name]
-        if ":" in name:
-            prefix, shortname = name.split(":", 1)
-            if strict and prefix not in self.get_prefixes():
-                raise NamespaceError(f"unknown prefix in: {name}")
-            return shortname
         if strict:
             raise NamespaceError(f"no short name for: {name}")
         return name

--- a/tripper/datadoc/context.py
+++ b/tripper/datadoc/context.py
@@ -411,6 +411,11 @@ class Context:
             self._create_caches()
         if name in self._shortnamed:
             return self._shortnamed[name]
+        if ":" in name:
+            prefix, shortname = name.split(":", 1)
+            if strict and prefix not in self.get_prefixes():
+                raise NamespaceError(f"unknown prefix in: {name}")
+            return shortname
         if strict:
             raise NamespaceError(f"no short name for: {name}")
         return name


### PR DESCRIPTION
# Description
Allow tabledoc to add prefix to the properties in the header.

Works in master - just added test for it...

## Type of change
- [ ] Bug fix and code cleanup
- [ ] New feature
- [ ] Documentation update
- [ ] Testing


## Checklist for the reviewer
This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
- [ ] Is the code properly tested?
