### PR TITLE
test(datadoc): cover IRI-valued search criteria

### DIFF
--- a/tests/datadoc/test_dataset.py
+++ b/tests/datadoc/test_dataset.py
@@ -997,6 +997,11 @@ def test_datadoc():
         SEMDATA.SEM_cement_batch2,
     ]
 
+    # IRI-valued criteria must be compared as RDF terms rather than strings.
+    assert search(ts, criteria={"distribution.generator": GEN.sem_hitachi}) == [
+        iri,
+    ]
+
     title = "Nested series of SEM images of cement batch2"
     dset = [SEMDATA.SEM_cement_batch2]
     # Search with predefined keyword

--- a/tests/datadoc/test_dataset.py
+++ b/tests/datadoc/test_dataset.py
@@ -998,7 +998,9 @@ def test_datadoc():
     ]
 
     # IRI-valued criteria must be compared as RDF terms rather than strings.
-    assert search(ts, criteria={"distribution.generator": GEN.sem_hitachi}) == [
+    assert search(
+        ts, criteria={"distribution.generator": GEN.sem_hitachi}
+    ) == [
         iri,
     ]
 


### PR DESCRIPTION
Adds regression coverage for issue #458, which verifies that a nested IRI-valued criterion matches the expected resource. The corresponding implementation is already present in the updated base branch. Testing: python -m pytest tests/datadoc/test_dataset.py::test_datadoc -q